### PR TITLE
Compressor: Replace FFmpeg on terminal with GStreamer vala bindings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update && apk add --no-cache \
     desktop-file-utils gobject-introspection-dev \
     adwaita-icon-theme font-dejavu \
     json-glib-dev libgee-dev \
+    gstreamer-dev gst-plugins-base-dev \
     uncrustify gdb \
     vala vala-language-server
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,22 @@ Checkout [Building](#building) if you need to run commands manually.
 
 If you're not using devcontainers, these are the dependencies:
 
-> `vala-language-server` and `gdb` are only need for development
+> `uncrustify`, `vala-language-server` and `gdb` are only need for development
+>
+> But for regular program use, you **will need** to install gstreamer plugins
 
-- Arch: `pacman -S base-devel meson ninja vala vala-language-server gtk4 libadwaita glib2 gobject-introspection uncrustify libgee`
-    - Development packages: `yay -S --noconfirm vala-language-server gdb`
-- Alpine for devcontainers: `sudo apk add alpine-sdk meson ninja gtk4.0-dev libadwaita-dev desktop-file-utils gobject-introspection-dev adwaita-icon-theme font-dejavu json-glib-dev libgee-dev uncrustify gdb vala vala-language-server`
-- Fedora: `dnf install cmake meson ninja vala glib2-devel libgee-devel json-glib-devel msgfmt gtk4-devel libadwaita-devel update-desktop-database ffmpeg`
+<!-- Outdated - Arch: `pacman -S base-devel meson ninja vala vala-language-server gtk4 libadwaita glib2 gobject-introspection uncrustify libgee`
+    - Development packages: `yay -S --noconfirm vala-language-server gdb` -->
+- Alpine for devcontainers: `sudo apk add alpine-sdk meson ninja gtk4.0-dev libadwaita-dev desktop-file-utils gobject-introspection-dev adwaita-icon-theme font-dejavu json-glib-dev libgee-dev gstreamer-dev gst-plugins-base-dev uncrustify gdb vala vala-language-server`
+- Fedora: `dnf install cmake meson ninja vala glib2-devel libgee-devel json-glib-devel msgfmt gtk4-devel libadwaita-devel update-desktop-database gstreamer1-devel gstreamer1-plugins-base-devel`
     - Development packages: `dnf install vala-language-server uncrustify gdb git`
+    - Basic codecs, for the basic flac/mp3 support: `dnf install gstreamer1-plugins-good`
+    - To install additional codecs, check [how to configure rpmfusion](https://rpmfusion.org/Configuration) and [install multimedia codecs](https://rpmfusion.org/Howto/Multimedia).
+```bash
+# Enable rpmfusion, and install codecs
+sudo dnf install -y https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+sudo dnf group install -y multimedia
+```
 
 ### Steps
 

--- a/data/presets.json
+++ b/data/presets.json
@@ -3,20 +3,31 @@
         "mp3": {
             "name": "MPEG / mp3",
             "extension": "mp3",
-            "video": true,
-            "codec": "libmp3lame"
+            "encoder": "lamemp3enc",
+            "bitrateMult": 1,
+            "filters": [
+                "mpegaudioparse",
+                "xingmux",
+                "id3v2mux"
+            ]
         },
         "m4a": {
             "name": "AAC / m4a",
             "extension": "m4a",
-            "video": true,
-            "codec": "aac"
+            "encoder": "avenc_aac",
+            "bitrateMult": 1000,
+            "filters": [
+                "mp4mux"
+            ]
         },
-        "vogg": {
-            "name": "Vorbis / ogg",
+        "oogg": {
+            "name": "Opus / ogg",
             "extension": "ogg",
-            "video": false,
-            "codec": "libvorbis"
+            "encoder": "avenc_aac",
+            "bitrateMult": 1000,
+            "filters": [
+                "opusenc"
+            ]
         }
     },
     "quality_presets": {
@@ -33,8 +44,8 @@
             "samplerate": 44100
         },
         "libre": {
-            "name": "Libre (Standard w/Vorbis)",
-            "format": "vogg",
+            "name": "Libre (Standard w/Opus)",
+            "format": "oogg",
             "bitrate": 128,
             "samplerate": 44100
         },

--- a/data/presets.json
+++ b/data/presets.json
@@ -21,9 +21,9 @@
             ]
         },
         "oogg": {
-            "name": "Opus / ogg",
+            "name": "Vorbis / ogg",
             "extension": "ogg",
-            "encoder": "opusenc",
+            "encoder": "vorbisenc",
             "bitrateMult": 1000,
             "filters": [
                 "oggmux"

--- a/data/presets.json
+++ b/data/presets.json
@@ -23,10 +23,10 @@
         "oogg": {
             "name": "Opus / ogg",
             "extension": "ogg",
-            "encoder": "avenc_aac",
+            "encoder": "opusenc",
             "bitrateMult": 1000,
             "filters": [
-                "opusenc"
+                "oggmux"
             ]
         }
     },

--- a/src/compress_config.vala
+++ b/src/compress_config.vala
@@ -37,8 +37,9 @@ public interface Press.Clonable<T> {
 public struct Press.FormatConfig {
     public string name;
     public string extension;
-    public bool attach_video;
-    public string codec;
+    public string encoder;
+    public int bitrate_multiplier;
+    public string[] filters;
 }
 
 public struct Press.QualityConfig {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -133,6 +133,30 @@ namespace Press.Compressor{
 
     }
 
+    public class FileDuplicator : FileHandler {
+        public FileDuplicator () {
+        }
+
+        public void process(File source, File target) {
+            source.copy_async.begin (
+                target,
+                FileCopyFlags.ALL_METADATA | FileCopyFlags.OVERWRITE,
+                Priority.DEFAULT,
+                null,
+                null,
+                (obj, res) => {
+                try {
+                    source.copy_async.end (res);
+                } catch ( Error err ){
+                    warning (@"Error trying to copy "
+                             + @"$(source.get_path()) to $(target.get_path()). "
+                             + @"Message: $(err.message)");
+                }
+            });
+        }
+
+    }
+
     public class Compressor : Object {
         // note: ^\.?(?<name>\/[^\/\n]+)+(?<ext>\.[A-z0-9\._-]+)$
 
@@ -297,7 +321,8 @@ namespace Press.Compressor{
                     file_handler = new FileConverter (config.quality_config.format.encoder, config.quality_config.format.filters);
                     file_handler.process (source_file, target_file);
                 } else if( config.copy_noaudio_files ){
-                    this.copy_file (source_file, target_file);
+                    file_handler = new FileDuplicator ();
+                    file_handler.process (source_file, target_file);
                 }
 
             } else {
@@ -349,24 +374,6 @@ namespace Press.Compressor{
                 is_audio = false;
                 is_video = false;
             }
-        }
-
-        private void copy_file(File source_file, File target_file) {
-            source_file.copy_async.begin (
-                target_file,
-                FileCopyFlags.ALL_METADATA | FileCopyFlags.OVERWRITE,
-                Priority.DEFAULT,
-                null,
-                null,
-                (obj, res) => {
-                try {
-                    source_file.copy_async.end (res);
-                } catch ( Error err ){
-                    warning (@"Error trying to copy "
-                             + @"$(source_file.get_path()) to $(target_file.get_path()). "
-                             + @"Message: $(err.message)");
-                }
-            });
         }
 
         public void cancel_process() {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -61,9 +61,12 @@ namespace Press.Compressor{
             try {
                 pipeline = create_pipeline ("convert-pipeline-" + source.get_basename ());
 
-                add_pipeline_filters (filters);
+                add_pipeline_filters ();
 
+                // TODO: try putting it above configure_elements();
                 decodebin.pad_added.connect (decodebin_pad_added);
+
+                configure_elements (source, target);
 
                 pipeline.set_state (Gst.State.PLAYING);
                 play ();
@@ -89,7 +92,7 @@ namespace Press.Compressor{
             decodebin = Gst.ElementFactory.make ("decodebin", "decodebin");
             Gst.Element ? audioconvert = Gst.ElementFactory.make ("audioconvert", "audioconvert");
             Gst.Element ? audioresample = Gst.ElementFactory.make ("audioresample", "audioresample");
-            Gst.Element ? encoder = Gst.ElementFactory.make (this.encoder_name, "encoder");
+            encoder = Gst.ElementFactory.make (this.encoder_name, "encoder");
 
             Gst.Element ?[] elements = { source, sink, decodebin, audioconvert, audioresample, encoder };
             foreach(Gst.Element ? element in elements){
@@ -102,10 +105,11 @@ namespace Press.Compressor{
             if( !source.link (decodebin) || !audioconvert.link_many (audioresample, encoder))
                 throw new CompressError.ELEMENT_LINK (@"Failed to link necessary elements of pipeline");
 
+            this.element_after_decodebin = audioconvert;
             return pipeline;
         }
 
-        private void add_pipeline_filters(string[] filters)
+        private void add_pipeline_filters()
         throws CompressError.ELEMENT_NULL, CompressError.ELEMENT_LINK {
             Gst.Element last_element = this.encoder;
 
@@ -126,7 +130,30 @@ namespace Press.Compressor{
                 throw new CompressError.ELEMENT_LINK (@"Failed to link the las element with the sink");
         }
 
-        private void decodebin_pad_added(Gst.Pad pad) {
+        private void decodebin_pad_added(Gst.Element src, Gst.Pad pad) {
+            Gst.Pad sink_pad = element_after_decodebin.get_static_pad ("sink");
+
+            if( sink_pad.is_linked ())
+                return;
+
+            Gst.Caps caps = pad.query_caps (null);
+            if( caps == null || caps.is_empty ())
+                return;
+
+            unowned Gst.Structure structure = caps.get_structure (0);
+            string pad_type = structure.get_name ();
+            if( !pad_type.has_prefix ("audio/x-raw"))
+                return;
+
+            if( pad.link (sink_pad) != Gst.PadLinkReturn.OK )
+                return;
+        }
+
+        private void configure_elements(File source_file, File target_file) {
+            source.set ("location", source_file.get_path ());
+            sink.set ("location", target_file.get_path ());
+            encoder.set ("bitrate", quality.bitrate * quality.format.bitrate_multiplier);
+            // TODO: samplerate
         }
 
         private void play() {
@@ -323,7 +350,7 @@ namespace Press.Compressor{
             FileHandler file_handler;
             if( valid_folder && (config.replace_destination_files || !file_exists)){
                 if( is_audio ){
-                    file_handler = new FileConverter (config.quality_config.format.encoder, config.quality_config.format.filters);
+                    file_handler = new FileConverter (config.quality_config);
                     file_handler.process (source_file, target_file);
                 } else if( config.copy_noaudio_files ){
                     file_handler = new FileDuplicator ();

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -32,24 +32,29 @@ namespace Press.Compressor{
         ELEMENT_LINK
     }
 
-    public interface FileHandler {
+    public interface FileHandler : Object {
         public abstract void process(File source, File target);
 
     }
 
-    public class FileConverter : FileHandler {
+    public class FileConverter : Object, FileHandler {
         private string[] filters;
         private string encoder_name;
+        private Press.QualityConfig quality;
 
         private Gst.Pipeline pipeline;
         private Gst.Element source;
         private Gst.Element sink;
         private Gst.Element decodebin;
         private Gst.Element encoder;
+        private Gst.Element element_after_decodebin;
 
-        public FileConverter (string encoder, string[] filters) {
-            this.filters = filters;
-            encoder_name = encoder;
+        public FileConverter (Press.QualityConfig quality) {
+            assert (quality.format.encoder != null);
+            assert (quality.format.filters != null);
+            filters = quality.format.filters;
+            encoder_name = quality.format.encoder;
+            this.quality = quality;
         }
 
         private void process(File source, File target) {
@@ -133,7 +138,7 @@ namespace Press.Compressor{
 
     }
 
-    public class FileDuplicator : FileHandler {
+    public class FileDuplicator : Object, FileHandler {
         public FileDuplicator () {
         }
 

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -64,7 +64,6 @@ namespace Press.Compressor{
 
                 add_pipeline_filters ();
 
-                // TODO: try putting it above configure_elements();
                 decodebin.pad_added.connect (decodebin_pad_added);
 
                 configure_elements (source, target);

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -206,10 +206,12 @@ namespace Press.Compressor{
         private bool process_running = false;
 
         private Regex file_extension_regex;
+        private int discoverer_timeout;
 
-        public Compressor () {
+        public Compressor (int discoverer_timeout = 3) {
             try {
                 this.file_extension_regex = new Regex ("(?<=\\.)[A-z0-9_-]+$");
+                this.discoverer_timeout = discoverer_timeout;
             } catch ( Error err ){
                 error (@"Error initializing regex for file extensions. Cannot continue.\nMessage: $(err.message)");
             }
@@ -329,9 +331,7 @@ namespace Press.Compressor{
             string relative_path = source_file_path.replace (source_folder_path, "");
             string target_file_path = target_folder_path + relative_path;
 
-            bool is_audio;
-            bool is_video;
-            this.check_streams (source_file, out is_audio, out is_video);
+            bool is_audio = check_streams (source_file);
             if( is_audio ){
                 try {
                     target_file_path = this.file_extension_regex.replace (
@@ -360,7 +360,7 @@ namespace Press.Compressor{
                 }
 
             } else {
-                debug (@"Skipping file: $(target_file.get_path())\n");
+                message (@"Skipping file: $(target_file.get_path())\n");
             }
         }
 
@@ -386,28 +386,22 @@ namespace Press.Compressor{
             return exists;
         }
 
-        private void check_streams(File file, out bool is_audio, out bool is_video) {
-            // TODO (gstreamer): replace
-            string command = @"ffprobe -loglevel error -show_entries stream=codec_type -of default=nw=1 \"$(file.get_path())\"";
-            is_audio = false;
-            is_video = false;
+        private bool check_streams(File file) {
+            bool is_audio = false;
 
             try {
-                string standard_output = "";
-                string standard_error = "";
-                int wait_status = 0;
-                Process.spawn_command_line_sync (command,
-                                                 out standard_output,
-                                                 out standard_error,
-                                                 out wait_status);
-                is_audio = standard_output.contains ("codec_type=audio");
-                is_video = standard_output.contains ("codec_type=video");
+                var discoverer = new Gst.PbUtils.Discoverer (discoverer_timeout * Gst.SECOND);
+                string file_uri = file.get_uri ();
+                Gst.PbUtils.DiscovererInfo info = discoverer.discover_uri (file_uri);
 
+                foreach(var stream_info in info.get_stream_list ()){
+                    is_audio = is_audio || stream_info.get_stream_type_nick () == "audio";
+                }
             } catch ( Error err ){
-                warning (@"Error checking if file is audio/video. $(err.message)");
-                is_audio = false;
-                is_video = false;
+                debug (@"Failed to discover the information of file $(file.get_path()) - Message: $(err.message)");
             }
+
+            return is_audio;
         }
 
         public void cancel_process() {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -24,269 +24,285 @@
  */
 using Gee;
 
-public class Press.Compressor : Object {
-    // note: ^\.?(?<name>\/[^\/\n]+)+(?<ext>\.[A-z0-9\._-]+)$
+namespace Press.Compressor{
 
-    private Press.CompressConfig config;
+    errordomain CompressError {
+        PIPELINE_FAIL,
+        ELEMENT_NULL,
+        ELEMENT_LINK
+    }
 
-    private File source_folder;
-    private File target_folder;
+    public interface FileHandler {
+        public abstract void process(File source, File target);
 
-    public signal void working_on_file(string path);
-    public signal void cancelled();
+    }
 
-    private bool process_cancel = false;
-    private bool process_running = false;
+    public class Compressor : Object {
+        // note: ^\.?(?<name>\/[^\/\n]+)+(?<ext>\.[A-z0-9\._-]+)$
 
-    private Regex file_extension_regex;
+        private Press.CompressConfig config;
 
-    public Compressor () {
-        try {
-            this.file_extension_regex = new Regex ("(?<=\\.)[A-z0-9_-]+$");
-        } catch ( Error err ){
-            error (@"Error initializing regex for file extensions. Cannot continue.\nMessage: $(err.message)");
+        private File source_folder;
+        private File target_folder;
+
+        public signal void working_on_file(string path);
+        public signal void cancelled();
+
+        private bool process_cancel = false;
+        private bool process_running = false;
+
+        private Regex file_extension_regex;
+
+        public Compressor () {
+            try {
+                this.file_extension_regex = new Regex ("(?<=\\.)[A-z0-9_-]+$");
+            } catch ( Error err ){
+                error (@"Error initializing regex for file extensions. Cannot continue.\nMessage: $(err.message)");
+            }
         }
-    }
 
-    private void start_process() {
-        this.process_cancel = false;
-        this.process_running = true;
-    }
+        private void start_process() {
+            this.process_cancel = false;
+            this.process_running = true;
+        }
 
-    private void stop_process() {
-        this.process_cancel = false;
-        this.process_running = false;
-    }
+        private void stop_process() {
+            this.process_cancel = false;
+            this.process_running = false;
+        }
 
-    public async void compress_library_async(Press.CompressConfig config) {
-        if( this.process_running )return;
-        this.start_process ();
+        public async void compress_library_async(Press.CompressConfig config) {
+            if( this.process_running )return;
+            this.start_process ();
 
-        this.config = config;
+            this.config = config;
 
-        this.source_folder = File.new_for_path (config.source_path);
-        this.target_folder = File.new_for_path (config.target_path);
+            this.source_folder = File.new_for_path (config.source_path);
+            this.target_folder = File.new_for_path (config.target_path);
 
-        assert (this.source_folder.query_exists (null));
-        assert (this.target_folder.query_exists (null));
+            assert (this.source_folder.query_exists (null));
+            assert (this.target_folder.query_exists (null));
 
-        var children = this.get_children (this.source_folder);
+            var children = this.get_children (this.source_folder);
 
 
-        // Inside the try, every thread is added to the pool
-        // When the try {} block is done, it starts running them.
-        try {
-            // TODO: if ThreadPool throws an error, it might not allow the yield to ever continue
-            var pool = new ThreadPool<File>.with_owned_data((file) => {
-                if( !this.process_cancel ){
+            // Inside the try, every thread is added to the pool
+            // When the try {} block is done, it starts running them.
+            try {
+                // TODO: if ThreadPool throws an error, it might not allow the yield to ever continue
+                var pool = new ThreadPool<File>.with_owned_data((file) => {
+                    if( !this.process_cancel ){
+                        Idle.add (() => {
+                            this.working_on_file (file.get_basename ());
+                            return Source.REMOVE;
+                        });
+                        this.process_file (file);
+                    }
+                }, (int) GLib.get_num_processors (), false);
+
+                foreach( File file in children ){
+                    pool.add (file);
+                }
+
+                new Thread<void>("wait_thread", () => {
+                    ThreadPool.free ((owned) pool, false, true);
                     Idle.add (() => {
-                        this.working_on_file (file.get_basename ());
+                        compress_library_async.callback ();
                         return Source.REMOVE;
                     });
-                    this.process_file (file);
-                }
-            }, (int) GLib.get_num_processors (), false);
-
-            foreach( File file in children ){
-                pool.add (file);
-            }
-
-            new Thread<void>("wait_thread", () => {
-                ThreadPool.free ((owned) pool, false, true);
-                Idle.add (() => {
-                    compress_library_async.callback ();
-                    return Source.REMOVE;
                 });
-            });
 
-            yield;
-        } catch ( ThreadError err ){
-            critical ("Error creating thread pool in compressor. %s", err.message);
-        }
-
-        // if we are continuing because the process has been cancelled
-        if( this.process_cancel ){
-            this.cancelled ();
-        }
-
-        this.stop_process ();
-    }
-
-    private ArrayList<File> get_children(File folder) {
-        var children = new ArrayList<File>();
-        this._get_children (folder, children);
-
-        return children;
-    }
-
-    private void _get_children(File folder, ArrayList<File> children) {
-        return_if_fail (folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY);
-
-        try {
-            var enumerator = folder.enumerate_children (
-                FileAttribute.STANDARD_NAME + "," +
-                FileAttribute.STANDARD_TYPE,
-                FileQueryInfoFlags.NONE,
-                null);
-
-            FileInfo info;
-            while((info = enumerator.next_file ()) != null ){
-                string name = info.get_name ();
-                File file = folder.get_child (name);
-
-                bool is_folder = info.get_file_type () == FileType.DIRECTORY;
-
-                if( is_folder ){
-                    this._get_children (file, children);
-                } else {
-                    children.add (file);
-                }
+                yield;
+            } catch ( ThreadError err ){
+                critical ("Error creating thread pool in compressor. %s", err.message);
             }
 
-            enumerator.close ();
+            // if we are continuing because the process has been cancelled
+            if( this.process_cancel ){
+                this.cancelled ();
+            }
 
-        } catch ( Error err ){
-            message ("Error: %s\n", err.message);
+            this.stop_process ();
         }
-    }
 
-    // public async void compress_file_async(string source_file_path, string target_file_path) {
+        private ArrayList<File> get_children(File folder) {
+            var children = new ArrayList<File>();
+            this._get_children (folder, children);
 
-    // }
+            return children;
+        }
 
-    private void process_file(File source_file) {
-        string source_folder_path = this.source_folder.get_path ();
-        string target_folder_path = this.target_folder.get_path ();
-        string source_file_path = source_file.get_path ();
+        private void _get_children(File folder, ArrayList<File> children) {
+            return_if_fail (folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY);
 
-        string relative_path = source_file_path.replace (source_folder_path, "");
-        string target_file_path = target_folder_path + relative_path;
-
-        bool is_audio;
-        bool is_video;
-        this.check_streams (source_file, out is_audio, out is_video);
-        if( is_audio ){
             try {
-                target_file_path = this.file_extension_regex.replace (
-                    target_file_path,
-                    target_file_path.length,
-                    0,
-                    config.quality_config.format.extension);
+                var enumerator = folder.enumerate_children (
+                    FileAttribute.STANDARD_NAME + "," +
+                    FileAttribute.STANDARD_TYPE,
+                    FileQueryInfoFlags.NONE,
+                    null);
+
+                FileInfo info;
+                while((info = enumerator.next_file ()) != null ){
+                    string name = info.get_name ();
+                    File file = folder.get_child (name);
+
+                    bool is_folder = info.get_file_type () == FileType.DIRECTORY;
+
+                    if( is_folder ){
+                        this._get_children (file, children);
+                    } else {
+                        children.add (file);
+                    }
+                }
+
+                enumerator.close ();
+
             } catch ( Error err ){
-                error ("Error trying to change extension name. Message: %s\n",
-                       err.message);
+                message ("Error: %s\n", err.message);
             }
         }
 
-        File target_file = File.new_for_path (target_file_path);
-        bool valid_folder = this.ensure_directory_exists (target_file);
-        bool file_exists = target_file.query_exists ();
+        // public async void compress_file_async(string source_file_path, string target_file_path) {
 
-        if( valid_folder && (config.replace_destination_files || !file_exists)){
+        // }
+
+        private void process_file(File source_file) {
+            string source_folder_path = this.source_folder.get_path ();
+            string target_folder_path = this.target_folder.get_path ();
+            string source_file_path = source_file.get_path ();
+
+            string relative_path = source_file_path.replace (source_folder_path, "");
+            string target_file_path = target_folder_path + relative_path;
+
+            bool is_audio;
+            bool is_video;
+            this.check_streams (source_file, out is_audio, out is_video);
             if( is_audio ){
-                this.convert_file (source_file, target_file, is_video && config.quality_config.format.attach_video);
-            } else if( config.copy_noaudio_files ){
-                this.copy_file (source_file, target_file);
-            }
-        } else {
-            debug (@"Skipping file: $(target_file.get_path())\n");
-        }
-    }
-
-    private bool ensure_directory_exists(File target_file) {
-        File ? target_parent = target_file.get_parent ();
-
-        bool exists = false;
-
-        // NOTE: parent can be null for '/'
-        if( target_parent != null ){
-            exists = target_parent.query_exists (null);
-
-            if( !exists ){
                 try {
-                    target_parent.make_directory_with_parents (null);
-                    exists = true;
+                    target_file_path = this.file_extension_regex.replace (
+                        target_file_path,
+                        target_file_path.length,
+                        0,
+                        config.quality_config.format.extension);
                 } catch ( Error err ){
-                    warning (@"Error creating folders for target file. Message: $(err.message)");
+                    error ("Error trying to change extension name. Message: %s\n",
+                           err.message);
                 }
             }
+
+            File target_file = File.new_for_path (target_file_path);
+            bool valid_folder = this.ensure_directory_exists (target_file);
+            bool file_exists = target_file.query_exists ();
+
+            if( valid_folder && (config.replace_destination_files || !file_exists)){
+                if( is_audio ){
+                    this.convert_file (source_file, target_file, is_video && config.quality_config.format.attach_video);
+                } else if( config.copy_noaudio_files ){
+                    this.copy_file (source_file, target_file);
+                }
+            } else {
+                debug (@"Skipping file: $(target_file.get_path())\n");
+            }
         }
 
-        return exists;
-    }
+        private bool ensure_directory_exists(File target_file) {
+            File ? target_parent = target_file.get_parent ();
 
-    private void check_streams(File file, out bool is_audio, out bool is_video) {
-        string command = @"ffprobe -loglevel error -show_entries stream=codec_type -of default=nw=1 \"$(file.get_path())\"";
-        is_audio = false;
-        is_video = false;
+            bool exists = false;
 
-        try {
-            string standard_output = "";
-            string standard_error = "";
-            int wait_status = 0;
-            Process.spawn_command_line_sync (command,
-                                             out standard_output,
-                                             out standard_error,
-                                             out wait_status);
-            is_audio = standard_output.contains ("codec_type=audio");
-            is_video = standard_output.contains ("codec_type=video");
+            // NOTE: parent can be null for '/'
+            if( target_parent != null ){
+                exists = target_parent.query_exists (null);
 
-        } catch ( Error err ){
-            warning (@"Error checking if file is audio/video. $(err.message)");
+                if( !exists ){
+                    try {
+                        target_parent.make_directory_with_parents (null);
+                        exists = true;
+                    } catch ( Error err ){
+                        warning (@"Error creating folders for target file. Message: $(err.message)");
+                    }
+                }
+            }
+
+            return exists;
+        }
+
+        private void check_streams(File file, out bool is_audio, out bool is_video) {
+            // TODO (gstreamer): replace
+            string command = @"ffprobe -loglevel error -show_entries stream=codec_type -of default=nw=1 \"$(file.get_path())\"";
             is_audio = false;
             is_video = false;
-        }
-    }
 
-    private void convert_file(File source_file, File target_file, bool attach_video) {
-        // if it's a video, include a -map v:0 (any video channels to 0)
-        // TODO: it could error if a sound file had more than 1 video channel...
-        // that's an edge case, though.
-        string command = attach_video
+            try {
+                string standard_output = "";
+                string standard_error = "";
+                int wait_status = 0;
+                Process.spawn_command_line_sync (command,
+                                                 out standard_output,
+                                                 out standard_error,
+                                                 out wait_status);
+                is_audio = standard_output.contains ("codec_type=audio");
+                is_video = standard_output.contains ("codec_type=video");
+
+            } catch ( Error err ){
+                warning (@"Error checking if file is audio/video. $(err.message)");
+                is_audio = false;
+                is_video = false;
+            }
+        }
+
+        private void convert_file(File source_file, File target_file, bool attach_video) {
+            // if it's a video, include a -map v:0 (any video channels to 0)
+            // TODO: it could error if a sound file had more than 1 video channel...
+            // that's an edge case, though.
+            string command = attach_video
             ? @"ffmpeg -v warning -i \"$(source_file.get_path())\" -map a:0 -ar $(config.quality_config.samplerate) -c:a $(config.quality_config.format.codec) -b:a $(config.quality_config.bitrate)k -c:v mjpeg -map v:0 -movflags +faststart \"$(target_file.get_path())\" -y"
             : @"ffmpeg -v warning -i \"$(source_file.get_path())\" -map a:0 -ar $(config.quality_config.samplerate) -c:a $(config.quality_config.format.codec) -b:a $(config.quality_config.bitrate)k \"$(target_file.get_path())\" -y";
-        // TODO: reformat into multiple lines
+            // TODO: reformat into multiple lines
 
-        debug (@"Command: $command");
-        try {
-            string standard_output = "";
-            string standard_error = "";
-            int wait_status = 0;
-            Process.spawn_command_line_sync (command,
-                                             out standard_output,
-                                             out standard_error,
-                                             out wait_status);
+            debug (@"Command: $command");
+            try {
+                string standard_output = "";
+                string standard_error = "";
+                int wait_status = 0;
+                Process.spawn_command_line_sync (command,
+                                                 out standard_output,
+                                                 out standard_error,
+                                                 out wait_status);
 
-            debug (@"\nOutput: $standard_output\n");
-            debug (@"\nError: $standard_error\n");
-            debug (@"\nWait status: $wait_status\n");
-        } catch ( Error err ){
-            warning (@"Error trying to convert file $(source_file.get_path()). Message: $(err.message)");
+                debug (@"\nOutput: $standard_output\n");
+                debug (@"\nError: $standard_error\n");
+                debug (@"\nWait status: $wait_status\n");
+            } catch ( Error err ){
+                warning (@"Error trying to convert file $(source_file.get_path()). Message: $(err.message)");
+            }
+
+            return;
         }
 
-        return;
-    }
+        private void copy_file(File source_file, File target_file) {
+            source_file.copy_async.begin (
+                target_file,
+                FileCopyFlags.ALL_METADATA | FileCopyFlags.OVERWRITE,
+                Priority.DEFAULT,
+                null,
+                null,
+                (obj, res) => {
+                try {
+                    source_file.copy_async.end (res);
+                } catch ( Error err ){
+                    warning (@"Error trying to copy "
+                             + @"$(source_file.get_path()) to $(target_file.get_path()). "
+                             + @"Message: $(err.message)");
+                }
+            });
+        }
 
-    private void copy_file(File source_file, File target_file) {
-        source_file.copy_async.begin (
-            target_file,
-            FileCopyFlags.ALL_METADATA | FileCopyFlags.OVERWRITE,
-            Priority.DEFAULT,
-            null,
-            null,
-            (obj, res) => {
-            try {
-                source_file.copy_async.end (res);
-            } catch ( Error err ){
-                warning (@"Error trying to copy "
-                         + @"$(source_file.get_path()) to $(target_file.get_path()). "
-                         + @"Message: $(err.message)");
-            }
-        });
-    }
+        public void cancel_process() {
+            this.process_cancel = true;
+        }
 
-    public void cancel_process() {
-        this.process_cancel = true;
     }
 
 }

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -291,12 +291,15 @@ namespace Press.Compressor{
             bool valid_folder = this.ensure_directory_exists (target_file);
             bool file_exists = target_file.query_exists ();
 
+            FileHandler file_handler;
             if( valid_folder && (config.replace_destination_files || !file_exists)){
                 if( is_audio ){
-                    this.convert_file (source_file, target_file, is_video && config.quality_config.format.attach_video);
+                    file_handler = new FileConverter (config.quality_config.format.encoder, config.quality_config.format.filters);
+                    file_handler.process (source_file, target_file);
                 } else if( config.copy_noaudio_files ){
                     this.copy_file (source_file, target_file);
                 }
+
             } else {
                 debug (@"Skipping file: $(target_file.get_path())\n");
             }

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -37,6 +37,102 @@ namespace Press.Compressor{
 
     }
 
+    public class FileConverter : FileHandler {
+        private string[] filters;
+        private string encoder_name;
+
+        private Gst.Pipeline pipeline;
+        private Gst.Element source;
+        private Gst.Element sink;
+        private Gst.Element decodebin;
+        private Gst.Element encoder;
+
+        public FileConverter (string encoder, string[] filters) {
+            this.filters = filters;
+            encoder_name = encoder;
+        }
+
+        private void process(File source, File target) {
+            try {
+                pipeline = create_pipeline ("convert-pipeline-" + source.get_basename ());
+
+                add_pipeline_filters (filters);
+
+                decodebin.pad_added.connect (decodebin_pad_added);
+
+                pipeline.set_state (Gst.State.PLAYING);
+                play ();
+                pipeline.set_state (Gst.State.NULL);
+
+            } catch ( CompressError err ){
+                critical (@"Error trying to compress $(source.get_path()) - $(err.code): $(err.message)");
+            }
+
+            pipeline = null;
+        }
+
+        private Gst.Pipeline create_pipeline(string name)
+        throws CompressError.PIPELINE_FAIL, CompressError.ELEMENT_LINK, CompressError.ELEMENT_NULL {
+            Gst.Pipeline ? pipeline = new Gst.Pipeline (name);
+
+            if( pipeline == null )
+                throw new CompressError.PIPELINE_FAIL ("Failed to create a pipeline");
+
+            source = Gst.ElementFactory.make ("filesrc");
+            sink = Gst.ElementFactory.make ("filesink", "sink");
+
+            decodebin = Gst.ElementFactory.make ("decodebin", "decodebin");
+            Gst.Element ? audioconvert = Gst.ElementFactory.make ("audioconvert", "audioconvert");
+            Gst.Element ? audioresample = Gst.ElementFactory.make ("audioresample", "audioresample");
+            Gst.Element ? encoder = Gst.ElementFactory.make (this.encoder_name, "encoder");
+
+            Gst.Element ?[] elements = { source, sink, decodebin, audioconvert, audioresample, encoder };
+            foreach(Gst.Element ? element in elements){
+                if( elements == null )
+                    throw new CompressError.ELEMENT_NULL (@"Failed to create a necessary element of pipeline");
+
+                pipeline.add (element);
+            }
+
+            if( !source.link (decodebin) || !audioconvert.link_many (audioresample, encoder))
+                throw new CompressError.ELEMENT_LINK (@"Failed to link necessary elements of pipeline");
+
+            return pipeline;
+        }
+
+        private void add_pipeline_filters(string[] filters)
+        throws CompressError.ELEMENT_NULL, CompressError.ELEMENT_LINK {
+            Gst.Element last_element = this.encoder;
+
+            foreach(string filter_name in filters){
+                Gst.Element ? filter = Gst.ElementFactory.make (filter_name, null);
+                if( filter == null )
+                    throw new CompressError.ELEMENT_NULL (@"Failed to create $filter_name");
+
+                pipeline.add (filter);
+
+                if( !last_element.link (filter))
+                    throw new CompressError.ELEMENT_LINK (@"Failed to link filter $filter_name with the last element");
+
+                last_element = filter;
+            }
+
+            if( !last_element.link (sink))
+                throw new CompressError.ELEMENT_LINK (@"Failed to link the las element with the sink");
+        }
+
+        private void decodebin_pad_added(Gst.Pad pad) {
+        }
+
+        private void play() {
+            Gst.Bus bus = pipeline.get_bus ();
+            bus.timed_pop_filtered (Gst.CLOCK_TIME_NONE, Gst.MessageType.ERROR | Gst.MessageType.EOS);
+
+            bus = null;
+        }
+
+    }
+
     public class Compressor : Object {
         // note: ^\.?(?<name>\/[^\/\n]+)+(?<ext>\.[A-z0-9\._-]+)$
 
@@ -250,35 +346,6 @@ namespace Press.Compressor{
                 is_audio = false;
                 is_video = false;
             }
-        }
-
-        private void convert_file(File source_file, File target_file, bool attach_video) {
-            // if it's a video, include a -map v:0 (any video channels to 0)
-            // TODO: it could error if a sound file had more than 1 video channel...
-            // that's an edge case, though.
-            string command = attach_video
-            ? @"ffmpeg -v warning -i \"$(source_file.get_path())\" -map a:0 -ar $(config.quality_config.samplerate) -c:a $(config.quality_config.format.codec) -b:a $(config.quality_config.bitrate)k -c:v mjpeg -map v:0 -movflags +faststart \"$(target_file.get_path())\" -y"
-            : @"ffmpeg -v warning -i \"$(source_file.get_path())\" -map a:0 -ar $(config.quality_config.samplerate) -c:a $(config.quality_config.format.codec) -b:a $(config.quality_config.bitrate)k \"$(target_file.get_path())\" -y";
-            // TODO: reformat into multiple lines
-
-            debug (@"Command: $command");
-            try {
-                string standard_output = "";
-                string standard_error = "";
-                int wait_status = 0;
-                Process.spawn_command_line_sync (command,
-                                                 out standard_output,
-                                                 out standard_error,
-                                                 out wait_status);
-
-                debug (@"\nOutput: $standard_output\n");
-                debug (@"\nError: $standard_error\n");
-                debug (@"\nWait status: $wait_status\n");
-            } catch ( Error err ){
-                warning (@"Error trying to convert file $(source_file.get_path()). Message: $(err.message)");
-            }
-
-            return;
         }
 
         private void copy_file(File source_file, File target_file) {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -47,6 +47,7 @@ namespace Press.Compressor{
         private Gst.Element sink;
         private Gst.Element decodebin;
         private Gst.Element encoder;
+        private Gst.Element samplerate_capsfilter;
         private Gst.Element element_after_decodebin;
 
         public FileConverter (Press.QualityConfig quality) {
@@ -92,9 +93,10 @@ namespace Press.Compressor{
             decodebin = Gst.ElementFactory.make ("decodebin", "decodebin");
             Gst.Element ? audioconvert = Gst.ElementFactory.make ("audioconvert", "audioconvert");
             Gst.Element ? audioresample = Gst.ElementFactory.make ("audioresample", "audioresample");
+            samplerate_capsfilter = Gst.ElementFactory.make ("capsfilter", "samplerate-capsfilter");
             encoder = Gst.ElementFactory.make (this.encoder_name, "encoder");
 
-            Gst.Element ?[] elements = { source, sink, decodebin, audioconvert, audioresample, encoder };
+            Gst.Element ?[] elements = { source, sink, decodebin, audioconvert, audioresample, samplerate_capsfilter, encoder };
             foreach(Gst.Element ? element in elements){
                 if( elements == null )
                     throw new CompressError.ELEMENT_NULL (@"Failed to create a necessary element of pipeline");
@@ -102,7 +104,7 @@ namespace Press.Compressor{
                 pipeline.add (element);
             }
 
-            if( !source.link (decodebin) || !audioconvert.link_many (audioresample, encoder))
+            if( !source.link (decodebin) || !audioconvert.link_many (audioresample, samplerate_capsfilter, encoder))
                 throw new CompressError.ELEMENT_LINK (@"Failed to link necessary elements of pipeline");
 
             this.element_after_decodebin = audioconvert;
@@ -153,7 +155,7 @@ namespace Press.Compressor{
             source.set ("location", source_file.get_path ());
             sink.set ("location", target_file.get_path ());
             encoder.set ("bitrate", quality.bitrate * quality.format.bitrate_multiplier);
-            // TODO: samplerate
+            samplerate_capsfilter.set ("caps", Gst.Caps.from_string (@"audio/x-raw,rate=$(quality.samplerate)"));
         }
 
         private void play() {

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -150,12 +150,20 @@ public class Press.ConfigPage : Adw.NavigationPage {
         foreach(string member in formats_obj.get_members ()){
             Json.Object format_obj = formats_obj.get_object_member (member);
 
+            // Find the filters
+            var filters_obj = format_obj.get_array_member ("filters");
+            var filters = new ArrayList<string>();
+            foreach(var filter_node in filters_obj.get_elements ()){
+                filters.add (filter_node.get_string ());
+            }
+
             Press.FormatConfig format = Press.FormatConfig () {
                 name = format_obj.get_string_member ("name"),
                 extension = format_obj.get_string_member ("extension"),
-                attach_video = format_obj.get_boolean_member ("video"),
-                codec = format_obj.get_string_member ("codec")
+                encoder = format_obj.get_string_member ("encoder"),
+                filters = filters.to_array ()
             };
+
             format_list[member] = format;
         }
     }

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -161,7 +161,8 @@ public class Press.ConfigPage : Adw.NavigationPage {
                 name = format_obj.get_string_member ("name"),
                 extension = format_obj.get_string_member ("extension"),
                 encoder = format_obj.get_string_member ("encoder"),
-                filters = filters.to_array ()
+                filters = filters.to_array (),
+                bitrate_multiplier = (int32) format_obj.get_int_member ("bitrateMult")
             };
 
             format_list[member] = format;

--- a/src/main.vala
+++ b/src/main.vala
@@ -28,6 +28,8 @@ int main(string[] args) {
     Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
     Intl.textdomain (Config.GETTEXT_PACKAGE);
 
+    Gst.init (ref args);
+
     var app = new Press.Application ();
     return app.run (args);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ press_deps = [
   dependency('json-glib-1.0', required: true),
   dependency('gee-0.8', required: true),
   dependency('gstreamer-1.0', required: true),
+  dependency('gstreamer-pbutils-1.0', required: true),
 ]
 
 press_sources += gnome.compile_resources(

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,7 +5,7 @@ press_sources = [
 
   'application.vala',
   'config_page.vala',
-  'window.vala'
+  'window.vala',
 ]
 
 press_deps = [
@@ -13,17 +13,21 @@ press_deps = [
   dependency('gtk4'),
   dependency('libadwaita-1', version: '>= 1.4'),
   dependency('json-glib-1.0', required: true),
-  dependency('gee-0.8', required: true)
+  dependency('gee-0.8', required: true),
+  dependency('gstreamer-1.0', required: true),
 ]
 
-press_sources += gnome.compile_resources('press-resources',
+press_sources += gnome.compile_resources(
+  'press-resources',
   'ui/press.gresource.xml',
   c_name: 'press',
-  source_dir: ['ui']
+  source_dir: ['ui'],
 )
 
-executable('press', press_sources,
+executable(
+  'press',
+  press_sources,
   dependencies: press_deps,
   include_directories: config_inc,
-       install: true,
+  install: true,
 )

--- a/src/window.vala
+++ b/src/window.vala
@@ -43,11 +43,11 @@ public class Press.Window : Adw.ApplicationWindow {
     [GtkChild]
     private unowned Adw.NavigationView navigation_view;
 
-    private Press.Compressor compressor;
+    private Compressor.Compressor compressor;
 
     public Window (Gtk.Application app) {
         application = app;
-        compressor = new Compressor ();
+        compressor = new Compressor.Compressor ();
 
 
         // Compress button


### PR DESCRIPTION
Replaces the FFmpeg command line calls, for proper GStreamer. Using vala bindings for that.

Performance is marginally faster, but not by much. Except for OGG, where GStreamer doubled the performance - but I'm not including it since I think that was user error. Also, this is not indicative of FFmpeg performance as a whole, probably just the scuffed implementation using terminal commands.
```
Format  FFmpeg  GStreamer
m4a_192 35s     32s
mp3_128 18s     14s         
```

CHANGES:
1. formats on presets.json have different attributes and values
2. FormatConfig now has different attributes
3. compressor uses a strategy pattern for handling files, each FileHandler does it's own thing
4. compressor now uses gstreamer for transcoding/converting files
5. the project now has GStreamer as a dependency, and gst-plugins-base-devel for pbutils
6. installing GStreamer codecs are now necessary - the README reflects that
7. deprecated Arch dependencies, since I don't currently use it