### PR TITLE
Heavily refactor code in src - make more maintainable, patch bugs, refactor compressor, remove comments, apply code style guidelines

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -9,7 +9,7 @@ you can use GNOME Builder for a more straight-forward experience.
 
 ### Native, with Meson
 
-The inteded development environment, specially with [Development containers](https://containers.dev).
+The intended development environment, specially with [Development containers](https://containers.dev).
 
 But you can check [Dependencies](#dependencies) for local development.
 
@@ -96,6 +96,38 @@ just install
 ```
 
 ## Contributors Guide
+
+### Code Style Guidelines
+
+
+For this project, use [Elementary OS' Guidelines](https://docs.elementary.io/develop/writing-apps/code-style) with some extra steps:
+
+1. String interpolation `@"word $variable $(obj.call ())"` is generally more readable than `.printf()`. With some exceptions:
+    - Very long strings — such as error messages
+    - Number formatting
+2. Probably OK to use `as` in scenarios where you absolutely know that's what it is, like a `[GtkCallback]`
+3. Try to use `this.` sparingly.
+4. For `[GtkChild]` tags when declaring children, write the tag in the same line as the declaration.
+	```vala
+	[GtkChild] private unowned Adw.ActionRow source_directory_row;
+	```
+    - This does NOT include other tags, like `[GtkCallback]` 
+5. Try to avoid using `constructor {}` syntax, unless it is necessary (i.e. a template)
+6. Document all public methods and sometimes properties. 
+    - Private methods should be documented, but it's optional if they aren't called, or are descriptive enough. (i.e. on_button_pressed isn't called)
+    - Private attributes/properties aren't required to have comments
+    - Public properties don't absolutely need it, but it is recommended
+    - When modifying a method, remember to also update it's existing in-code documentation
+8. Format your code, preferably before a commit. Checkout [formatting](#formatting)
+9. You should avoid stray values, defining constants are preferred.
+    - It's hard to change it afterwards
+    - It's hard to understand what it is
+    - Except for error messages!
+    - OK `const string CUSTOM_NAME = "CustomName"`
+    - NOT `names["CustomName"].call()`
+    - NOT `num * 3.1415`
+        - Instead: `const double PI = 3.1415` and `num * PI`
+    - You don't have to enforce it strictly, but it certainly helps
 
 ### Formatting
 This project uses _EditorConfig_ and `vala-lint`.

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,6 +7,8 @@ src/main.vala
 src/window.vala
 src/config_page.vala
 src/application.vala
+src/translatable.vala
+src/presets_loader.vala
 src/ui/window.ui
 src/ui/shortcuts-dialog.ui
 src/ui/config_page.ui

--- a/src/compress_config.vala
+++ b/src/compress_config.vala
@@ -27,7 +27,7 @@ using Gee;
 /**
  * To create deep copies of itself
  */
-public interface Press.Clonable<T> {
+public interface Press.Cloneable<T> {
     /**
      * Create a deep copy of ``this``
      */
@@ -68,7 +68,7 @@ public struct Press.QualityConfig {
  *   method(cloned);
  * }}}
  */
-public class Press.CompressConfig : Press.Clonable<Press.CompressConfig> {
+public class Press.CompressConfig : Press.Cloneable<Press.CompressConfig> {
     public string source_path { get; set; }
     public string target_path { get; set; }
     public Press.QualityConfig quality_config;

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -29,7 +29,10 @@ namespace Press {
     errordomain CompressError {
         PIPELINE_FAIL,
         ELEMENT_NULL,
-        ELEMENT_LINK
+        ELEMENT_LINK,
+        IGNORED_FILE,
+        PRE_PROCESS,
+        PROCESS
     }
 
     /**
@@ -322,7 +325,16 @@ namespace Press {
                             this.working_on_file (file.get_basename ());
                             return Source.REMOVE;
                         });
-                        this.process_file (file);
+
+                        debug (@"Processing file $(file.get_path ())");
+
+                        try {
+                            process_file (file);
+                        } catch (CompressError.IGNORED_FILE err) {
+                            debug (@"Skipping $(file.get_path ()). Reason: $(err.message)");
+                        } catch (Error err) {
+                            warning (@"Failed to process $(file.get_path ()). Error: $(err.message)");
+                        }
                     }
                 }, (int) GLib.get_num_processors (), false);
 
@@ -351,8 +363,8 @@ namespace Press {
          *
          * The children parameter is internal.
          */
-        private ArrayList<File> get_children (File folder, ArrayList<File> _children = new ArrayList<File>()) 
-        requires (folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY)
+        private ArrayList<File> get_children (File folder, ArrayList<File> _children = new ArrayList<File> ())
+        requires (folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY) // vala-lint:block-opening-brace-space-before
         {
             try {
                 var enumerator = folder.enumerate_children (FileAttribute.STANDARD_NAME + ","
@@ -388,7 +400,10 @@ namespace Press {
          * Processes a {@link GLib.File}. Uses {@link Press.Compressor.FileConverter} for conversions,
          * and {@link Press.Compressor.FileDuplicator} for file copies.
          *
-         * The duplicator will be called for files that don't have audio, and  only if ``copy_noaudio_files`` is
+         * Will throw ``CompressError.IGNORED_FILE`` if the file didn't meet the criteria, or other
+         * {@link Press.CompressError} if the operation finished unsuccessfully.
+         *
+         * The duplicator will be called for files that don't have audio, and only if ``copy_noaudio_files`` is
          * enabled in the ``config``.
          *
          * The target bitrate and samplerate, are limited to the existing properties for each file. If bitrate is
@@ -396,11 +411,9 @@ namespace Press {
          * File.
          *
          * If the detected samplerate is 0, the file will be ignored, as it's likely corrupted in some way.
-         *
-         * For the reasons above, a message may be printed saying "Skipping file". Unless it's followed by an error
-         * message, it's likely fine.
          */
-        private void process_file (File source_file) {
+        private void process_file (File source_file)
+        throws Error, RegexError, CompressError {
             string source_folder_path = this.source_folder.get_path ();
             string target_folder_path = this.target_folder.get_path ();
             string source_file_path = source_file.get_path ();
@@ -412,46 +425,38 @@ namespace Press {
             int bitrate;
             int samplerate;
             check_streams (source_file, out is_audio, out bitrate, out samplerate);
-            Press.CompressConfig file_config = config;
+            Press.CompressConfig file_config = config.clone ();
 
             if (is_audio) {
-                if (samplerate == 0) {
-                    critical (@"Samplerate of file $(source_file.get_path()) is 0. It's likely corrupted.");
-                    return;
-                }
-                if (bitrate < config.quality_config.bitrate || samplerate < config.quality_config.samplerate) {
-                    file_config = config.clone ();
+                if (samplerate == 0)
+                    throw new CompressError.PRE_PROCESS (@"Samplerate of file $(source_file.get_path()) is 0. "
+                                                         + "It's likely corrupted.");
 
+                if (bitrate < config.quality_config.bitrate || samplerate < config.quality_config.samplerate) {
                     file_config.quality_config.bitrate = min (bitrate, file_config.quality_config.bitrate);
                     file_config.quality_config.samplerate = min (samplerate, file_config.quality_config.samplerate);
                 }
 
-                try {
-                    target_file_path = this.file_extension_regex.replace (target_file_path,
-                                                                          target_file_path.length,
-                                                                          0,
-                                                                          file_config.quality_config.format.extension);
-                } catch (Error err) {
-                    critical (@"Error trying to change extension name. Message: $(err.message)");
-                    return;
-                }
+                target_file_path = this.file_extension_regex.replace (target_file_path,
+                                                                      target_file_path.length,
+                                                                      0,
+                                                                      file_config.quality_config.format.extension);
             }
 
             File target_file = File.new_for_path (target_file_path);
-            bool valid_folder = this.ensure_directory_exists (target_file);
+            ensure_directory_exists (target_file);
             bool file_exists = target_file.query_exists ();
 
+            if (file_exists && !file_config.replace_destination_files)
+                throw new CompressError.IGNORED_FILE ("File exists, and replace destination files is disabled");
+
             FileHandler file_handler;
-            if (valid_folder && (file_config.replace_destination_files || !file_exists)) {
-                if (is_audio) {
-                    file_handler = new FileConverter (file_config.quality_config);
-                    file_handler.process (source_file, target_file);
-                } else if (file_config.copy_noaudio_files) {
-                    file_handler = new FileDuplicator ();
-                    file_handler.process (source_file, target_file);
-                }
-            } else {
-                message (@"Skipping file: $(target_file.get_path())\n");
+            if (is_audio) {
+                file_handler = new FileConverter (file_config.quality_config);
+                file_handler.process (source_file, target_file);
+            } else if (file_config.copy_noaudio_files) {
+                file_handler = new FileDuplicator ();
+                file_handler.process (source_file, target_file);
             }
         }
 
@@ -465,30 +470,16 @@ namespace Press {
         /**
          * Makes sure the directory for a target file exists. Will create folders as necessary.
          *
-         * Will return whether the operation was successful or not.
-         *
-         * @return Whether the operation was successful.
+         * Fails if the operation was unsuccessful.
          */
-        private bool ensure_directory_exists (File target_file) {
+        private void ensure_directory_exists (File target_file)
+        throws Error {
             File? target_parent = target_file.get_parent ();
 
-            bool exists = false;
-
             // NOTE: parent can be null for '/'
-            if (target_parent != null) {
-                exists = target_parent.query_exists (null);
-
-                if (!exists) {
-                    try {
-                        target_parent.make_directory_with_parents (null);
-                        exists = true;
-                    } catch (Error err) {
-                        warning (@"Error creating folders for target file. Message: $(err.message)");
-                    }
-                }
+            if (target_parent != null && !target_parent.query_exists ()) {
+                target_parent.make_directory_with_parents ();
             }
-
-            return exists;
         }
 
         /**

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -324,7 +324,6 @@ namespace Press {
             var children = get_children (this.source_folder);
 
             try {
-                // TODO: if ThreadPool throws an error, it might not allow the yield to ever continue
                 var pool = new ThreadPool<File>.with_owned_data ((file) => {
                     if (!cancelled) {
                         Idle.add (() => {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -446,8 +446,7 @@ namespace Press.Compressor {
                 }
 
                 try {
-                    target_file_path = this.file_extension_regex.replace (
-                                                                          target_file_path,
+                    target_file_path = this.file_extension_regex.replace (target_file_path,
                                                                           target_file_path.length,
                                                                           0,
                                                                           file_config.quality_config.format.extension);

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -24,7 +24,7 @@
  */
 using Gee;
 
-namespace Press.Compressor {
+namespace Press {
 
     errordomain CompressError {
         PIPELINE_FAIL,

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -26,7 +26,7 @@ using Gee;
 
 namespace Press {
 
-    errordomain CompressError {
+    public errordomain CompressError {
         PIPELINE_FAIL,
         ELEMENT_NULL,
         ELEMENT_LINK,
@@ -48,7 +48,7 @@ namespace Press {
          * @param source An existing file to process
          * @param target The file to write to
          */
-        public abstract void process (File source, File target);
+        public abstract void process (File source, File target) throws CompressError.PROCESS;
     }
 
     /**
@@ -78,7 +78,8 @@ namespace Press {
         /**
          * {@inheritDoc}
          */
-        private void process (File source, File target) {
+        private void process (File source, File target)
+        throws CompressError.PROCESS {
             try {
                 pipeline = create_pipeline ("convert-pipeline-" + source.get_basename ());
 
@@ -92,7 +93,7 @@ namespace Press {
                 play ();
                 pipeline.set_state (Gst.State.NULL);
             } catch (CompressError err) {
-                critical (@"Error trying to compress $(source.get_path()) - $(err.code): $(err.message)");
+                throw new CompressError.PROCESS (@"Failed to process file: $(err.message)");
             }
 
             pipeline = null;
@@ -237,7 +238,8 @@ namespace Press {
         /**
          * {@inheritDoc}
          */
-        public void process (File source, File target) {
+        public void process (File source, File target)
+        throws CompressError.PROCESS {
             source.copy_async.begin (target,
                                      FileCopyFlags.ALL_METADATA | FileCopyFlags.OVERWRITE,
                                      Priority.DEFAULT,
@@ -247,8 +249,7 @@ namespace Press {
                 try {
                     source.copy_async.end (res);
                 } catch (Error err) {
-                    warning (@"Error trying to copy $(source.get_path()) to $(target.get_path()). "
-                             + @"Message: $(err.message)");
+                    throw new CompressError.PROCESS (@"Failed to copy: $(err.message)");
                 }
             });
         }
@@ -332,6 +333,8 @@ namespace Press {
                             process_file (file);
                         } catch (CompressError.IGNORED_FILE err) {
                             debug (@"Skipping $(file.get_path ()). Reason: $(err.message)");
+                        } catch (CompressError.PROCESS err) {
+                            warning (@"Failed during processing on $(file.get_path ()). Error: $(err.message)");
                         } catch (Error err) {
                             warning (@"Failed to process $(file.get_path ()). Error: $(err.message)");
                         }

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -422,15 +422,8 @@ namespace Press {
                 if (bitrate < config.quality_config.bitrate || samplerate < config.quality_config.samplerate) {
                     file_config = config.clone ();
 
-                    file_config.quality_config.bitrate =
-                        bitrate < file_config.quality_config.bitrate
-                            ? bitrate
-                            : file_config.quality_config.bitrate;
-
-                    file_config.quality_config.samplerate =
-                        samplerate < file_config.quality_config.samplerate
-                            ? samplerate
-                            : file_config.quality_config.samplerate;
+                    file_config.quality_config.bitrate = min (bitrate, file_config.quality_config.bitrate);
+                    file_config.quality_config.samplerate = min (samplerate, file_config.quality_config.samplerate);
                 }
 
                 try {
@@ -460,6 +453,13 @@ namespace Press {
             } else {
                 message (@"Skipping file: $(target_file.get_path())\n");
             }
+        }
+
+        /**
+         * Returns the lesser number of the two
+         */
+        private int min (int a, int b) {
+            return a < b ? a : b;
         }
 
         /**

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -286,7 +286,7 @@ namespace Press.Compressor {
                 this.file_extension_regex = new Regex ("(?<=\\.)[A-z0-9_-]+$");
                 this.discoverer_timeout = discoverer_timeout;
             } catch (Error err) {
-                error (@"Error initializing regex for file extensions. Cannot continue.\nMessage: $(err.message)");
+                error (@"Error initializing regex for file extensions. Cannot continue. - Message: $(err.message)");
             }
         }
 
@@ -571,6 +571,7 @@ namespace Press.Compressor {
 
                 size = info.get_size ();
             } catch (Error err) {
+                debug (@"Failed to get file size for $(file.get_path ()). Message: $(err.message)");
             }
 
             return size;

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -235,8 +235,7 @@ namespace Press.Compressor {
          * {@inheritDoc}
          */
         public void process (File source, File target) {
-            source.copy_async.begin (
-                                     target,
+            source.copy_async.begin (target,
                                      FileCopyFlags.ALL_METADATA | FileCopyFlags.OVERWRITE,
                                      Priority.DEFAULT,
                                      null,
@@ -419,7 +418,7 @@ namespace Press.Compressor {
          *
          * If the detected samplerate is 0, the file will be ignored, as it's likely corrupted in some way.
          *
-         * For the reasons above, a message may be printed saying "Skipping file". Unless it's followed by an error 
+         * For the reasons above, a message may be printed saying "Skipping file". Unless it's followed by an error
          * message, it's likely fine.
          */
         private void process_file (File source_file) {
@@ -518,7 +517,7 @@ namespace Press.Compressor {
          * Creates a {@link Gst.PbUtils.Discoverer} and tries to look for audio properties in a {@link GLib.File}.
          *
          * If a samplerate is 0, this means the file is //likely corrupted//, or there was an issue parsing it.
-         * 
+         *
          * The Discoverer will look for it for as long as ``discoverer_timeout``.
          *
          * NOTE: A new Discoverer is created each time this method is called.
@@ -573,8 +572,7 @@ namespace Press.Compressor {
             int64 size = 0;
 
             try {
-                FileInfo info = file.query_info (
-                                                 FileAttribute.STANDARD_SIZE,
+                FileInfo info = file.query_info (FileAttribute.STANDARD_SIZE,
                                                  FileQueryInfoFlags.NONE,
                                                  null);
 

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -310,16 +310,18 @@ namespace Press.Compressor {
          * It uses multi threading to speed the process time.
          */
         public async void compress_library_async (Press.CompressConfig config) {
-            if (this.process_running)return;
-            this.start_process ();
+            if (this.process_running)
+                return;
 
             this.config = config;
 
             this.source_folder = File.new_for_path (config.source_path);
             this.target_folder = File.new_for_path (config.target_path);
 
-            assert (this.source_folder.query_exists (null));
-            assert (this.target_folder.query_exists (null));
+            return_if_fail (this.source_folder.query_exists ());
+            return_if_fail (this.target_folder.query_exists ());
+
+            this.start_process ();
 
             var children = this.get_children (this.source_folder);
 

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -135,7 +135,7 @@ namespace Press.Compressor {
         }
 
         /**
-         * Adds the parametrized filters to the pipleine, and links them along the sink.
+         * Adds the parametrized filters to the pipeline, and links them along the sink.
          */
         private void add_pipeline_filters ()
         throws CompressError.ELEMENT_NULL, CompressError.ELEMENT_LINK {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -522,8 +522,7 @@ namespace Press.Compressor {
 
             try {
                 var discoverer = new Gst.PbUtils.Discoverer (discoverer_timeout * Gst.SECOND);
-                string file_uri = file.get_uri ();
-                Gst.PbUtils.DiscovererInfo info = discoverer.discover_uri (file_uri);
+                Gst.PbUtils.DiscovererInfo info = discoverer.discover_uri (file.get_uri ());
 
                 var audio_streams = info.get_audio_streams ();
                 is_audio = audio_streams.length () > 0;

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -275,7 +275,7 @@ namespace Press {
         public signal void working_on_file (string path);
 
         private bool running = false;
-        public bool cancelled { get; private set; }
+        private bool cancelled = false;
 
         private Regex file_extension_regex;
         private int discoverer_timeout;
@@ -289,26 +289,22 @@ namespace Press {
             try {
                 file_extension_regex = new Regex ("(?<=\\.)[A-z0-9_-]+$");
                 this.discoverer_timeout = discoverer_timeout;
-                running = false;
-                cancelled = false;
             } catch (Error err) {
                 error (@"Error initializing regex for file extensions. Cannot continue. - Message: $(err.message)");
             }
         }
 
         /**
-         * Begins compressing a library. The source and target folders must exist.
-         *
-         * This is the main entry point. A callback will be sent once it has completed. Once it's done, you can check
-         * if it was cancelled using the public property ``cancelled``.
+         * Begins compressing a library, returns whether the operation was successful.
+         * The source and target folders must exist.
          *
          * Only a single compression can run at a time, although many files can be processed simultaneously
          *
          * It uses multi threading to speed the process time.
          */
-        public async void compress_library_async (Press.CompressConfig config) {
+        public async bool compress_library_async (Press.CompressConfig config) {
             if (running)
-                return;
+                return false;
 
             this.config = config;
 
@@ -316,7 +312,7 @@ namespace Press {
             target_folder = File.new_for_path (config.target_path);
 
             if (!source_folder.query_exists () || !target_folder.query_exists ())
-                return;
+                return false;
 
             running = true;
             cancelled = false;
@@ -363,6 +359,7 @@ namespace Press {
             }
 
             running = false;
+            return !cancelled;
         }
 
         /**

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -287,8 +287,8 @@ namespace Press {
          */
         public Compressor (int discoverer_timeout = 3) {
             try {
-                this.file_extension_regex = new Regex ("(?<=\\.)[A-z0-9_-]+$");
-                this.discoverer_timeout = discoverer_timeout;
+                file_extension_regex = new Regex ("(?<=\\.)[A-z0-9_-]+$");
+                discoverer_timeout = discoverer_timeout;
                 running = false;
                 cancelled = false;
             } catch (Error err) {
@@ -312,16 +312,16 @@ namespace Press {
 
             this.config = config;
 
-            this.source_folder = File.new_for_path (config.source_path);
-            this.target_folder = File.new_for_path (config.target_path);
+            source_folder = File.new_for_path (config.source_path);
+            target_folder = File.new_for_path (config.target_path);
 
-            if (!source_folder.query_exists () || !this.target_folder.query_exists ())
+            if (!source_folder.query_exists () || !target_folder.query_exists ())
                 return;
 
             running = true;
             cancelled = false;
 
-            var children = get_children (this.source_folder);
+            var children = get_children (source_folder);
 
             try {
                 var pool = new ThreadPool<File>.with_owned_data ((file) => {
@@ -387,7 +387,7 @@ namespace Press {
                     bool is_folder = info.get_file_type () == FileType.DIRECTORY;
 
                     if (is_folder) {
-                        this.get_children (file, _children);
+                        get_children (file, _children);
                     } else {
                         _children.add (file);
                     }
@@ -421,8 +421,8 @@ namespace Press {
          */
         private void process_file (File source_file)
         throws Error, RegexError, CompressError {
-            string source_folder_path = this.source_folder.get_path ();
-            string target_folder_path = this.target_folder.get_path ();
+            string source_folder_path = source_folder.get_path ();
+            string target_folder_path = target_folder.get_path ();
             string source_file_path = source_file.get_path ();
 
             string relative_path = source_file_path.replace (source_folder_path, "");
@@ -444,10 +444,10 @@ namespace Press {
                     file_config.quality_config.samplerate = min (samplerate, file_config.quality_config.samplerate);
                 }
 
-                target_file_path = this.file_extension_regex.replace (target_file_path,
-                                                                      target_file_path.length,
-                                                                      0,
-                                                                      file_config.quality_config.format.extension);
+                target_file_path = file_extension_regex.replace (target_file_path,
+                                                                 target_file_path.length,
+                                                                 0,
+                                                                 file_config.quality_config.format.extension);
             }
 
             File target_file = File.new_for_path (target_file_path);

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -265,13 +265,8 @@ namespace Press {
          */
         public signal void working_on_file (string path);
 
-        private bool process_cancel = false;
-        private bool process_running = false;
-        public bool cancelled {
-            get {
-                return this.process_cancel;
-            }
-        }
+        private bool running = false;
+        public bool cancelled { get; private set; }
 
         private Regex file_extension_regex;
         private int discoverer_timeout;
@@ -285,18 +280,11 @@ namespace Press {
             try {
                 this.file_extension_regex = new Regex ("(?<=\\.)[A-z0-9_-]+$");
                 this.discoverer_timeout = discoverer_timeout;
+                running = false;
+                cancelled = false;
             } catch (Error err) {
                 error (@"Error initializing regex for file extensions. Cannot continue. - Message: $(err.message)");
             }
-        }
-
-        private void start_process () {
-            this.process_cancel = false;
-            this.process_running = true;
-        }
-
-        private void stop_process () {
-            this.process_running = false;
         }
 
         /**
@@ -310,7 +298,7 @@ namespace Press {
          * It uses multi threading to speed the process time.
          */
         public async void compress_library_async (Press.CompressConfig config) {
-            if (this.process_running)
+            if (running)
                 return;
 
             this.config = config;
@@ -321,14 +309,15 @@ namespace Press {
             if (!source_folder.query_exists () || !this.target_folder.query_exists ())
                 return;
 
-            this.start_process ();
+            running = true;
+            cancelled = false;
 
             var children = this.get_children (this.source_folder);
 
             try {
                 // TODO: if ThreadPool throws an error, it might not allow the yield to ever continue
                 var pool = new ThreadPool<File>.with_owned_data ((file) => {
-                    if (!this.process_cancel) {
+                    if (!cancelled) {
                         Idle.add (() => {
                             this.working_on_file (file.get_basename ());
                             return Source.REMOVE;
@@ -354,7 +343,7 @@ namespace Press {
                 critical ("Error creating thread pool in compressor. %s", err.message);
             }
 
-            this.stop_process ();
+            running = false;
         }
 
         /**
@@ -578,8 +567,8 @@ namespace Press {
          *
          * The running processes will gracefully finish, and not stopped mid-way.
          */
-        public void cancel_process () {
-            this.process_cancel = true;
+        public void cancel () {
+            cancelled = true;
         }
     }
 }

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -240,18 +240,11 @@ namespace Press {
          */
         public void process (File source, File target)
         throws CompressError.PROCESS {
-            source.copy_async.begin (target,
-                                     FileCopyFlags.ALL_METADATA | FileCopyFlags.OVERWRITE,
-                                     Priority.DEFAULT,
-                                     null,
-                                     null,
-                                     (obj, res) => {
-                try {
-                    source.copy_async.end (res);
-                } catch (Error err) {
-                    throw new CompressError.PROCESS (@"Failed to copy: $(err.message)");
-                }
-            });
+            try {
+                source.copy (target, FileCopyFlags.ALL_METADATA | FileCopyFlags.OVERWRITE);
+            } catch (Error err) {
+                throw new CompressError.PROCESS (@"Failed to copy: $(err.message)");
+            }
         }
     }
 

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -255,8 +255,6 @@ namespace Press.Compressor {
      * Compresses files on a directory, given the target quality
      */
     public class Compressor : Object {
-        // note: ^\.?(?<name>\/[^\/\n]+)+(?<ext>\.[A-z0-9\._-]+)$
-
         private Press.CompressConfig config;
 
         private File source_folder;
@@ -298,7 +296,6 @@ namespace Press.Compressor {
         }
 
         private void stop_process () {
-            // this.process_cancel = false;
             this.process_running = false;
         }
 
@@ -326,9 +323,6 @@ namespace Press.Compressor {
 
             var children = this.get_children (this.source_folder);
 
-
-            // Inside the try, every thread is added to the pool
-            // When the try {} block is done, it starts running them.
             try {
                 // TODO: if ThreadPool throws an error, it might not allow the yield to ever continue
                 var pool = new ThreadPool<File>.with_owned_data ((file) => {
@@ -341,7 +335,7 @@ namespace Press.Compressor {
                     }
                 }, (int) GLib.get_num_processors (), false);
 
-                foreach ( File file in children ) {
+                foreach (File file in children) {
                     pool.add (file);
                 }
 
@@ -379,8 +373,7 @@ namespace Press.Compressor {
             return_if_fail (folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY);
 
             try {
-                var enumerator = folder.enumerate_children (
-                                                            FileAttribute.STANDARD_NAME + ","
+                var enumerator = folder.enumerate_children (FileAttribute.STANDARD_NAME + ","
                                                             + FileAttribute.STANDARD_TYPE,
                                                             FileQueryInfoFlags.NONE,
                                                             null);
@@ -520,7 +513,7 @@ namespace Press.Compressor {
          *
          * The Discoverer will look for it for as long as ``discoverer_timeout``.
          *
-         * NOTE: A new Discoverer is created each time this method is called.
+         * A new Discoverer is created each time this method is called.
          */
         private void check_streams (File file, out bool is_audio, out int bitrate, out int samplerate) {
             is_audio = false;

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -356,7 +356,7 @@ namespace Press {
             return children;
         }
 
-        private void _get_children (File folder, ArrayList<File> children) {
+        private void _get_children (File folder, ArrayList<File> children = new ArrayList<File>()) {
             return_if_fail (folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY);
 
             try {
@@ -365,8 +365,8 @@ namespace Press {
                                                             FileQueryInfoFlags.NONE,
                                                             null);
 
-                FileInfo info;
-                while ((info = enumerator.next_file ()) != null) {
+                FileInfo info = enumerator.next_file ();
+                while (info != null) {
                     string name = info.get_name ();
                     File file = folder.get_child (name);
 
@@ -377,6 +377,8 @@ namespace Press {
                     } else {
                         children.add (file);
                     }
+
+                    info = enumerator.next_file ();
                 }
 
                 enumerator.close ();

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -288,7 +288,7 @@ namespace Press {
         public Compressor (int discoverer_timeout = 3) {
             try {
                 file_extension_regex = new Regex ("(?<=\\.)[A-z0-9_-]+$");
-                discoverer_timeout = discoverer_timeout;
+                this.discoverer_timeout = discoverer_timeout;
                 running = false;
                 cancelled = false;
             } catch (Error err) {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -352,10 +352,6 @@ namespace Press.Compressor {
                 critical ("Error creating thread pool in compressor. %s", err.message);
             }
 
-            // if we are continuing because the process has been cancelled
-            if (this.process_cancel) {
-            }
-
             this.stop_process ();
         }
 

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -312,7 +312,7 @@ namespace Press {
             running = true;
             cancelled = false;
 
-            var children = this.get_children (this.source_folder);
+            var children = get_children (this.source_folder);
 
             try {
                 // TODO: if ThreadPool throws an error, it might not allow the yield to ever continue
@@ -348,17 +348,12 @@ namespace Press {
 
         /**
          * Returns the children in a given folder.
+         *
+         * The children parameter is internal.
          */
-        private ArrayList<File> get_children (File folder) {
-            var children = new ArrayList<File> ();
-            this._get_children (folder, children);
-
-            return children;
-        }
-
-        private void _get_children (File folder, ArrayList<File> children = new ArrayList<File>()) {
-            return_if_fail (folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY);
-
+        private ArrayList<File> get_children (File folder, ArrayList<File> _children = new ArrayList<File>()) 
+        requires (folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY)
+        {
             try {
                 var enumerator = folder.enumerate_children (FileAttribute.STANDARD_NAME + ","
                                                             + FileAttribute.STANDARD_TYPE,
@@ -373,9 +368,9 @@ namespace Press {
                     bool is_folder = info.get_file_type () == FileType.DIRECTORY;
 
                     if (is_folder) {
-                        this._get_children (file, children);
+                        this.get_children (file, _children);
                     } else {
-                        children.add (file);
+                        _children.add (file);
                     }
 
                     info = enumerator.next_file ();
@@ -385,6 +380,8 @@ namespace Press {
             } catch (Error err) {
                 message ("Error: %s\n", err.message);
             }
+
+            return _children;
         }
 
         /**

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -318,8 +318,8 @@ namespace Press.Compressor {
             this.source_folder = File.new_for_path (config.source_path);
             this.target_folder = File.new_for_path (config.target_path);
 
-            return_if_fail (this.source_folder.query_exists ());
-            return_if_fail (this.target_folder.query_exists ());
+            if (!source_folder.query_exists () || !this.target_folder.query_exists ())
+                return;
 
             this.start_process ();
 

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -220,9 +220,21 @@ namespace Press {
          *
          * It is called play, because the pipeline says this is the "PLAYING" state.
          */
-        private void play () {
+        private void play ()
+        throws CompressError.PROCESS {
             Gst.Bus bus = pipeline.get_bus ();
-            bus.timed_pop_filtered (Gst.CLOCK_TIME_NONE, Gst.MessageType.ERROR | Gst.MessageType.EOS);
+            Gst.Message msg = bus.timed_pop_filtered (Gst.CLOCK_TIME_NONE, Gst.MessageType.ERROR | Gst.MessageType.EOS);
+
+            if (msg != null && msg.type == Gst.MessageType.ERROR) {
+                GLib.Error err;
+                string debug_info;
+                msg.parse_error (out err, out debug_info);
+
+                throw new CompressError.PROCESS (@"Failed to convert. "
+                                                 + @" - Element: $(msg.src.name)."
+                                                 + @" - Error: $(err.message)"
+                                                 + @" - Debug info: $debug_info");
+            }
 
             bus = null;
         }

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -119,7 +119,9 @@ namespace Press.Compressor {
             samplerate_capsfilter = Gst.ElementFactory.make ("capsfilter", "samplerate-capsfilter");
             encoder = Gst.ElementFactory.make (this.encoder_name, "encoder");
 
-            Gst.Element?[] elements = { source, sink, decodebin, audioconvert, audioresample, samplerate_capsfilter, encoder };
+            Gst.Element?[] elements = {
+                source, sink, decodebin, audioconvert, audioresample, samplerate_capsfilter, encoder
+            };
             foreach (Gst.Element ? element in elements) {
                 if (elements == null)
                     throw new CompressError.ELEMENT_NULL (@"Failed to create a necessary element of pipeline");
@@ -243,8 +245,7 @@ namespace Press.Compressor {
                 try {
                     source.copy_async.end (res);
                 } catch (Error err) {
-                    warning (@"Error trying to copy "
-                             + @"$(source.get_path()) to $(target.get_path()). "
+                    warning (@"Error trying to copy $(source.get_path()) to $(target.get_path()). "
                              + @"Message: $(err.message)");
                 }
             });

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -51,12 +51,12 @@ public class Press.ConfigPage : Adw.NavigationPage {
     /**
      * A HashMap of formats with their keywords, as in the presets file. They keywords aren't the display names.
      */
-    public HashMap<string, Press.FormatConfig?> format_list;
+    public HashMap<string, Press.FormatConfig?> format_list { get; private set; }
 
     /**
      * A HashMap of Quality with their keywords, as in the presets file. They keywords aren't the display names.
      */
-    public HashMap<string, Press.QualityConfig?> quality_list;
+    public HashMap<string, Press.QualityConfig?> quality_list { get; private set; }
 
     /**
      * The current configuration. ''Do not modify this object directly'', clone it (``.clone()``) if needed.

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -25,20 +25,6 @@
 using Gee;
 using Json;
 
-namespace Press {
-    // Current preset names
-    // They must match the existing names on data/presets.json
-    const string[] TRANSLATABLE_PRESET_NAMES = {
-        N_ ("MPEG / mp3"),
-        N_ ("AAC / m4a"),
-        N_ ("Vorbis / ogg"),
-        N_ ("High Quality"),
-        N_ ("Standard Quality"),
-        N_ ("Libre (ogg)"),
-        N_ ("Compatibility"),
-    };
-}
-
 /**
  * The main configuration page. It actively updates a {@link Press.CompressConfig} as ``config``.
  *
@@ -74,7 +60,7 @@ public class Press.ConfigPage : Adw.NavigationPage {
 
     /**
      * The current configuration. ''Do not modify this object directly'', clone it (``.clone()``) if needed.
-     * 
+     *
      * This property is updated as things are selected on the {@link Press.ConfigPage}.
      */
     public Press.CompressConfig config { get; private set; }

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -92,7 +92,7 @@ public class Press.ConfigPage : Adw.NavigationPage {
 
     [GtkCallback]
     private void on_source_directory_clicked (Gtk.Button button) {
-        this.select_directory ((folder) => {
+        select_directory ((folder) => {
             string path = folder != null ? folder.get_path () : "nothing";
 
             config.source_path = path;
@@ -102,7 +102,7 @@ public class Press.ConfigPage : Adw.NavigationPage {
 
     [GtkCallback]
     private void on_target_directory_clicked (Gtk.Button button) {
-        this.select_directory ((folder) => {
+        select_directory ((folder) => {
             string? path = folder != null ? folder.get_path () : "nothing";
 
             config.target_path = path;

--- a/src/presets_loader.vala
+++ b/src/presets_loader.vala
@@ -66,8 +66,7 @@ namespace Press {
             try {
                 parser.load_from_file (presets_file.get_path ());
             } catch (Error err) {
-                throw new PresetsLoaderError.ERROR_LOADING_FILE (
-                                                                 @"Could not read file from path "
+                throw new PresetsLoaderError.ERROR_LOADING_FILE (@"Could not read file from path "
                                                                  + @"$(presets_file.get_path ()). File should exists.");
             }
 
@@ -166,11 +165,9 @@ namespace Press {
                 Press.FormatConfig? format = format_list[quality_obj.get_string_member ("format")];
 
                 if (format == null) {
-                    warning (
-                             "Couldn't load quality preset %s. Format %s doesn't exist.",
+                    warning ("Couldn't load quality preset %s. Format %s doesn't exist.",
                              quality_obj.get_string_member ("name"),
-                             quality_obj.get_string_member ("format")
-                    );
+                             quality_obj.get_string_member ("format"));
                 } else {
                     Press.QualityConfig quality = Press.QualityConfig () {
                         name = _(quality_obj.get_string_member ("name")),

--- a/src/presets_loader.vala
+++ b/src/presets_loader.vala
@@ -75,6 +75,7 @@ namespace Press {
             parse_presets_file_formats (root_obj);
             parse_presets_file_quality (root_obj);
 
+            /* Custom quality requires at least one */
             assert (format_list.size > 0);
             assert (quality_list.size > 0);
         }
@@ -87,7 +88,6 @@ namespace Press {
          * @param display_name should be sent already translated
          */
         public void add_custom_quality (string name, string display_name) {
-            // Will error unless there's an mp3 format
             quality_list[name] = { display_name, null, 128, 44100 };
         }
 

--- a/src/translatable.vala
+++ b/src/translatable.vala
@@ -1,0 +1,37 @@
+/* MIT License
+ *
+ * Copyright (c) 2026 Masakk1
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+namespace Press {
+    // Current preset names
+    // They must match the existing names on data/presets.json
+    const string[] TRANSLATABLE = {
+        N_ ("MPEG / mp3"),
+        N_ ("AAC / m4a"),
+        N_ ("Vorbis / ogg"),
+        N_ ("High Quality"),
+        N_ ("Standard Quality"),
+        N_ ("Libre (ogg)"),
+        N_ ("Compatibility"),
+    };
+}

--- a/src/ui/config_page.ui
+++ b/src/ui/config_page.ui
@@ -126,7 +126,7 @@
                     </property>
                     <child type="suffix">
                       <object class="GtkImage" id="samplerate_tooltip">
-                        <property name="visible">true</property>
+                        <property name="visible">false</property>
                         <property name="icon-name">dialog-warning-symbolic</property>
                         <property name="has-tooltip">true</property>
                         <property name="tooltip-text"

--- a/src/window.vala
+++ b/src/window.vala
@@ -135,7 +135,7 @@ public class Press.Window : Adw.ApplicationWindow {
     }
 
     private void cancel_compression () {
-        compressor.cancel_process ();
+        compressor.cancel ();
         change_working_on (_("cancelling"));
     }
 

--- a/src/window.vala
+++ b/src/window.vala
@@ -53,22 +53,22 @@ public class Press.Window : Adw.ApplicationWindow {
 
         // Compress button
         config_page.compress_button.clicked.connect (compress_button_clicked);
-        confirm_dialog.response.connect (this.answer_confirm_dialog);
+        confirm_dialog.response.connect (answer_confirm_dialog);
 
         // In compressing page
-        cancel_compressing_button.clicked.connect (this.open_cancel_dialog);
-        cancel_dialog.response.connect (this.answer_cancel_dialog);
-        this.compressor.working_on_file.connect (this.change_working_on);
+        cancel_compressing_button.clicked.connect (open_cancel_dialog);
+        cancel_dialog.response.connect (answer_cancel_dialog);
+        compressor.working_on_file.connect (change_working_on);
 
         // In done page
-        done_page_back_button.clicked.connect (this.return_config_page);
+        done_page_back_button.clicked.connect (return_config_page);
     }
 
     private void compress_button_clicked () {
         if (config_page.config.replace_destination_files) {
-            this.open_confirm_dialog ();
+            open_confirm_dialog ();
         } else {
-            this.begin_compression ();
+            begin_compression ();
         }
     }
 
@@ -78,7 +78,7 @@ public class Press.Window : Adw.ApplicationWindow {
 
     private void answer_confirm_dialog (string response) {
         if (response == "compress") {
-            this.begin_compression ();
+            begin_compression ();
         }
     }
 
@@ -88,12 +88,12 @@ public class Press.Window : Adw.ApplicationWindow {
 
     private void answer_cancel_dialog (string response) {
         if (response == "cancel") {
-            this.cancel_compression ();
+            cancel_compression ();
         }
     }
 
     private void change_working_on (string job) {
-        this.compressing_status_page.description = _("Working on %s").printf (job);
+        compressing_status_page.description = _("Working on %s").printf (job);
     }
 
     /**
@@ -112,9 +112,9 @@ public class Press.Window : Adw.ApplicationWindow {
         if (folders_exist) {
             navigation_view.push_by_tag ("compressing_page");
 
-            this.compressor.compress_library_async.begin (
-                                                          config, (obj, res) => {
-                this.compressor.compress_library_async.end (res);
+            compressor.compress_library_async.begin (
+                                                     config, (obj, res) => {
+                compressor.compress_library_async.end (res);
 
                 if (compressor.cancelled)
                     navigation_view.pop_to_tag ("config_page");

--- a/src/window.vala
+++ b/src/window.vala
@@ -29,25 +29,17 @@
 [GtkTemplate (ui = "/io/github/masakk1/press/window.ui")]
 public class Press.Window : Adw.ApplicationWindow {
 
-    [GtkChild]
-    private unowned Press.ConfigPage config_page;
+    [GtkChild] private unowned Press.ConfigPage config_page;
 
-    [GtkChild]
-    private unowned Adw.AlertDialog confirm_dialog;
-    [GtkChild]
-    private unowned Gtk.Button cancel_compressing_button;
-    [GtkChild]
-    private unowned Adw.AlertDialog cancel_dialog;
-    [GtkChild]
-    private unowned Adw.StatusPage compressing_status_page;
-    [GtkChild]
-    private unowned Gtk.Button done_page_back_button;
+    [GtkChild] private unowned Adw.AlertDialog confirm_dialog;
+    [GtkChild] private unowned Gtk.Button cancel_compressing_button;
+    [GtkChild] private unowned Adw.AlertDialog cancel_dialog;
+    [GtkChild] private unowned Adw.StatusPage compressing_status_page;
+    [GtkChild] private unowned Gtk.Button done_page_back_button;
 
-    [GtkChild]
-    private unowned Adw.NavigationView navigation_view;
+    [GtkChild] private unowned Adw.NavigationView navigation_view;
 
-    [GtkChild]
-    private unowned Adw.ToastOverlay toast_overlay;
+    [GtkChild] private unowned Adw.ToastOverlay toast_overlay;
 
     private Compressor compressor;
 

--- a/src/window.vala
+++ b/src/window.vala
@@ -113,12 +113,12 @@ public class Press.Window : Adw.ApplicationWindow {
             navigation_view.push_by_tag ("compressing_page");
 
             compressor.compress_library_async.begin (config, (obj, res) => {
-                compressor.compress_library_async.end (res);
+                bool successful = compressor.compress_library_async.end (res);
 
-                if (compressor.cancelled)
-                    navigation_view.pop_to_tag ("config_page");
-                else
+                if (successful)
                     navigation_view.push_by_tag ("done_page");
+                else
+                    navigation_view.pop_to_tag ("config_page");
             });
         } else {
             toast_overlay.add_toast (new Adw.Toast (_("Selected folders don't exist")));

--- a/src/window.vala
+++ b/src/window.vala
@@ -49,14 +49,14 @@ public class Press.Window : Adw.ApplicationWindow {
     [GtkChild]
     private unowned Adw.ToastOverlay toast_overlay;
 
-    private Compressor.Compressor compressor;
+    private Compressor compressor;
 
     /**
      * Creates the main Window
      */
     public Window (Gtk.Application app) {
         application = app;
-        compressor = new Compressor.Compressor ();
+        compressor = new Compressor ();
 
 
         // Compress button
@@ -102,7 +102,7 @@ public class Press.Window : Adw.ApplicationWindow {
 
     private void change_working_on (string job) {
         this.compressing_status_page.description = _("Working on %s").printf (job);
-}
+    }
 
     /**
      * Begins the compression.

--- a/src/window.vala
+++ b/src/window.vala
@@ -107,13 +107,12 @@ public class Press.Window : Adw.ApplicationWindow {
 
         var source_folder = File.new_for_path (config.source_path);
         var target_folder = File.new_for_path (config.target_path);
-        bool folders_exist = source_folder.query_exists (null) && target_folder.query_exists (null);
+        bool folders_exist = source_folder.query_exists () && target_folder.query_exists ();
 
         if (folders_exist) {
             navigation_view.push_by_tag ("compressing_page");
 
-            compressor.compress_library_async.begin (
-                                                     config, (obj, res) => {
+            compressor.compress_library_async.begin (config, (obj, res) => {
                 compressor.compress_library_async.end (res);
 
                 if (compressor.cancelled)


### PR DESCRIPTION
Closes #10 

## Description

This PR makes a lot of changes that were due, to hopefully avoid technical debt and make it easier for new contributors.

It makes a lot of breaking changes, that have been solved internally, and since internal stuff isn't probably used outside of this application, I don't think there's anything to worry about. But it might still warrant a version upgrade.

The Window is in need of a refactor, but I still need some help deciding what I'll do with it. For the time being, I've changed how a lot of Compressor behaves, making it nicer and cleaner. And even removed one of the linter issues. I have also applied the proposed style guidelines in #10, which might need to actually put on `docs/developers.md` on another PR.

Hopefully some bugs have been patched in the process, and if someone wants to maintain it, they'll have an easier time!

Most notably:

- Moved translatable strings to its own file
- Renamed interfaces (typo)
- Remove uncalled code, or unnecessary comments
- Patch some bugs
- Changed Compress' namespace
- Applied a lot of the code style guidelines
- Compressor now is handled through errors, instead of countless conditions

This doesn't:

- Move all the classes to individual files. That's something I'm planning on, but I might do that on another PR. This is already too big as it stands.

Issue #10 will be more up to date, but this is the current list of changes:

- [X] Application
- [X] Compress config
- [x] Compressor
  - [x] Applied style guidelines
  - [x] Make it so creating a compressor is `new Compressor()`, instead `new Compressor.Compressor()`
  - [x] Sort out the process running and cancelling. It works, but doesn't feel right.
  - [x] Remove the TODOs on Compressors
  - [x] Changes get_childen to return the ArrayList directly, no _get_children.
  - [x] Simplify capping on process_file, create a Math.Min function or something
  - [x] Not planned. Can't find this information again. ~~For get_num_processors, I think there was an automatic way to use as many as there are available.~~
  - [x] Make functions throw errors instead of booleans. Specially `ensure_directory_exists`
  - [x] Throw exceptions when the pipeline bus on FileConverter.play encounters an error
  - [x] Writte better error escalation on compress_library_async
  - [x] Fix asynchronous usage when not necessary
  - [X] Return a bool for the main entry point
- [x] Config Page
  - [x] Applied style guidelines
  - [X] Move translatable strings
  - [x] Hide the samplerate warning by default
- [x] Main
- [x] Presets Loader
  - [x] Applied style guidelines
  - [x] When adding the custom quality, it can load without an mp3 format, but there must be at least 1 format. Add a note to the existing assert checking for presets.json.
- [x] Window
  - [X] Applied style guidelines
  - [X] Remove some unnecessary parameters

## Checklist

- [X] Your code builds clean without any errors
- [X] Added in-code documentation
- [X] Ran the linter to ensure style guidelines were followed