### PR TITLE
Documentation generation recipe

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,10 @@ RUN apk update && apk add --no-cache \
     gstreamer-dev gst-plugins-base-dev \
     uncrustify gdb just \
     vala vala-language-server vala-lint \
-    gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav
+    gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav \
+    vala-doc graphviz npm
+
+RUN npm install -g serve
 
 # Create user adw, grant root access, remove password
 RUN useradd -m -s /bin/bash adw && \

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ core.*
 
 # Test results
 test-results/
+
+# Generated Documentation
+docs/press/

--- a/.justfile
+++ b/.justfile
@@ -1,4 +1,5 @@
 prefix := "/usr"
+docdir := "./docs/press"
 
 # Default recipe
 default:
@@ -26,6 +27,28 @@ lint:
 
 lint-fix:
     io.elementary.vala-lint src -c vala-lint.conf --fix
+
+# == Documentation ==
+
+# Clean and create the generated documentation directory
+docs-setup:
+    rm -r {{docdir}}
+    mkdir {{docdir}}
+
+docs-generate:
+    valadoc --force --package-name=press --package-version=0.2.0 \
+    --pkg=gtk4 --pkg=libadwaita-1 --pkg=json-glib-1.0 --pkg=gee-0.8 \
+    --pkg=gstreamer-1.0 --pkg=gstreamer-pbutils-1.0 \
+    -o {{docdir}} \
+    src/*.vala src/*.vapi \
+    --private
+
+# Serves the page in port 3000
+docs-serve port="3000":
+    npx serve {{docdir}} -p {{port}}
+
+# Quick macro to clean, generate, and serve
+docs: docs-setup docs-generate docs-serve
 
 # == Running ==
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -141,3 +141,27 @@ This project uses _EditorConfig_ and `vala-lint`.
 2. Run `vala-lint` to check your code
     - `just lint` will say the errors you have
     - `just lint-fix` will try to fix some issues
+
+### Generating docs
+
+To view the written documentation from a website, you can use `vala-doc`.
+
+```bash
+# Clean and setup the directory (only needed once)
+just docs-setup
+
+# Generate the documentation
+just docs-generate
+
+# Serve as a website on localhost:3000
+just docs-serve
+```
+
+You can also quickly run all of the above with. 
+However, running `docs-generate` is still required to update it while it's live.
+```bash
+just docs
+```
+
+> [!NOTE]
+> In VS Code, port 3000 was automatically routed for the devcontainer.

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -41,6 +41,10 @@ sudo dnf install cmake meson ninja vala glib2-devel libgee-devel json-glib-devel
 # Development packages
 sudo dnf install vala-language-server uncrustify gdb git
 
+# Documentation
+sudo dnf install valadoc graphviz npm
+sudo npm install -g serve
+
 # Just:
 sudo dnf install cargo
 cargo install just-lsp


### PR DESCRIPTION
Closes: #14 

## Description

Facilitate ways to automatically generate documentation based on the codebase, and make it available as a self-hosted static site.

The generated docs would be in docs/press

**Changes**
- Add dependencies for devcontainer, and stated them for Fedora in developer documentation
- Add recipe in just to setup and generate docs
- Add recipe to serve the static website on `localhost:3000`
- Document how to use this

**Dependencies added**
- vala-doc
- graphviz (vala doc requires it)
- npm
- serve (npm) 

**How to use**

It can be quickly generated with:
```bash
just docs
```
There's also :`docs-setup`, `docs-generate` and `docs-serve` for more granularity

## Screenshots

<img width="1144" height="916" alt="image" src="https://github.com/user-attachments/assets/89d22db7-2512-4950-8f52-cf145de16778" />

## Checklist

- [X] Added documentation

(other items don't apply)
