### PR TITLE
Feature/toggle properties

### DIFF
--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -462,7 +462,8 @@ namespace Press {
             if (file_exists && !file_config.replace_destination_files)
                 throw new CompressError.IGNORED_FILE ("File exists, and replace destination files is disabled");
 
-            debug (@"Processing $(source_file.get_basename ()) @ $(file_config.quality_config.bitrate) bps, $(file_config.quality_config.samplerate) Hz");
+            debug (@"Processing $(source_file.get_basename ()) @ "
+                   + "$(file_config.quality_config.bitrate) bps, $(file_config.quality_config.samplerate) Hz");
 
             FileHandler file_handler;
             if (is_audio) {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -190,14 +190,18 @@ namespace Press {
          * Configures the created elements. Adds encoder properties, links the samplerate caps filter.
          *
          * A bitrate multiplier of 0 means avoiding setting the bitrate entirely. Which is required for Lossless formats.
+         *
+         * If bitrate or samplerate is less or equal to 0, then they wont be enforced respectively.
          */
         private void configure_elements (File source_file, File target_file) {
             source.set ("location", source_file.get_path ());
             sink.set ("location", target_file.get_path ());
-            samplerate_capsfilter.set ("caps", Gst.Caps.from_string (@"audio/x-raw,rate=$(quality.samplerate)"));
 
-            if (quality.format.bitrate_multiplier > 0)
+            if (quality.bitrate * quality.format.bitrate_multiplier > 0)
                 encoder.set ("bitrate", quality.bitrate * quality.format.bitrate_multiplier);
+
+            if (quality.samplerate > 0)
+                samplerate_capsfilter.set ("caps", Gst.Caps.from_string (@"audio/x-raw,rate=$(quality.samplerate)"));
 
             // Encoder properties
             foreach (var property in quality.format.encoder_properties ) {
@@ -457,6 +461,8 @@ namespace Press {
 
             if (file_exists && !file_config.replace_destination_files)
                 throw new CompressError.IGNORED_FILE ("File exists, and replace destination files is disabled");
+
+            debug (@"Processing $(source_file.get_basename ()) @ $(file_config.quality_config.bitrate) bps, $(file_config.quality_config.samplerate) Hz");
 
             FileHandler file_handler;
             if (is_audio) {

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -41,6 +41,7 @@ public class Press.ConfigPage : Adw.NavigationPage {
     [GtkChild] private unowned Adw.ComboRow custom_format_selection;
     [GtkChild] private unowned Adw.SwitchRow replace_destination_files_switch;
     [GtkChild] private unowned Adw.SwitchRow copy_noaudio_files_switch;
+    [GtkChild] private unowned Adw.SpinRow samplerate_row;
     [GtkChild] private unowned Gtk.Image samplerate_tooltip;
 
     /**
@@ -213,6 +214,16 @@ public class Press.ConfigPage : Adw.NavigationPage {
 
         // Not a common samplerate
         samplerate_tooltip.visible = !(value == 44100 || value == 48000);
+    }
+
+    [GtkCallback]
+    private void on_samplerate_expand (GLib.Object obj, GLib.ParamSpec _) {
+        var expander_row = obj as Adw.ExpanderRow;
+        var expansion_enabled = expander_row.enable_expansion;
+
+        var custom_quality = quality_list[CUSTOM_QUALITY_NAME];
+        custom_quality.samplerate = expansion_enabled ? (int) samplerate_row.value : 0;
+        update_custom_quality (custom_quality);
     }
 
     [GtkCallback]

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -41,6 +41,7 @@ public class Press.ConfigPage : Adw.NavigationPage {
     [GtkChild] private unowned Adw.ComboRow custom_format_selection;
     [GtkChild] private unowned Adw.SwitchRow replace_destination_files_switch;
     [GtkChild] private unowned Adw.SwitchRow copy_noaudio_files_switch;
+    [GtkChild] private unowned Adw.SpinRow bitrate_row;
     [GtkChild] private unowned Adw.SpinRow samplerate_row;
     [GtkChild] private unowned Gtk.Image samplerate_tooltip;
 
@@ -200,6 +201,16 @@ public class Press.ConfigPage : Adw.NavigationPage {
 
         var custom_quality = quality_list[CUSTOM_QUALITY_NAME];
         custom_quality.bitrate = value;
+        update_custom_quality (custom_quality);
+    }
+
+    [GtkCallback]
+    private void on_bitrate_expand (GLib.Object obj, GLib.ParamSpec _) {
+        var expander_row = obj as Adw.ExpanderRow;
+        var expansion_enabled = expander_row.enable_expansion;
+
+        var custom_quality = quality_list[CUSTOM_QUALITY_NAME];
+        custom_quality.bitrate = expansion_enabled ? (int) bitrate_row.value : 0;
         update_custom_quality (custom_quality);
     }
 

--- a/src/presets_loader.vala
+++ b/src/presets_loader.vala
@@ -87,7 +87,7 @@ namespace Press {
          * @param display_name should be sent already translated
          */
         public void add_custom_quality (string name, string display_name) {
-            quality_list[name] = { display_name, null, 128, 44100 };
+            quality_list[name] = { display_name, null, 128, 0 };
         }
 
         /**

--- a/src/presets_loader.vala
+++ b/src/presets_loader.vala
@@ -87,7 +87,7 @@ namespace Press {
          * @param display_name should be sent already translated
          */
         public void add_custom_quality (string name, string display_name) {
-            quality_list[name] = { display_name, null, 128, 0 };
+            quality_list[name] = { display_name, null, 0, 0 };
         }
 
         /**

--- a/src/ui/config_page.ui
+++ b/src/ui/config_page.ui
@@ -95,18 +95,26 @@
                   </object>
                 </child>
                 <child>
-                  <object class="AdwSpinRow">
-                    <signal name="notify::value" handler="on_bitrate_changed"></signal>
-                    <property name="title" translatable="yes">Bitrate (Kbps)</property>
-                    <property name="adjustment">
-                      <object class="GtkAdjustment">
-                        <property name="lower">64</property>
-                        <property name="upper">320</property>
-                        <property name="value">128</property>
-                        <property name="page-increment">32</property>
-                        <property name="step-increment">16</property>
+                  <object class="AdwExpanderRow">
+                    <property name="title" translatable="yes">Change Bitrate</property>
+                    <property name="show-enable-switch">true</property>
+                    <property name="enable-expansion">false</property>
+                    <signal name="notify::enable-expansion" handler="on_bitrate_expand"></signal>
+                    <child>
+                      <object class="AdwSpinRow" id="bitrate_row">
+                        <signal name="notify::value" handler="on_bitrate_changed"></signal>
+                        <property name="title" translatable="yes">Kilo bits per second (Kbps)</property>
+                        <property name="adjustment">
+                          <object class="GtkAdjustment">
+                            <property name="lower">64</property>
+                            <property name="upper">320</property>
+                            <property name="value">128</property>
+                            <property name="page-increment">32</property>
+                            <property name="step-increment">16</property>
+                          </object>
+                        </property>
                       </object>
-                    </property>
+                    </child>
                   </object>
                 </child>
                 <child>

--- a/src/ui/config_page.ui
+++ b/src/ui/config_page.ui
@@ -86,9 +86,7 @@
             <child>
               <object class="AdwPreferencesGroup" id="custom_quality_group">
                 <property name="title" translatable="yes">Custom Target Quality</property>
-                <property
-                  name="description"
-                  translatable="yes">Manually configure the maximum target quality.</property>
+                <property name="description" translatable="yes">Manually configure the maximum target quality.</property>
                 <property name="visible">false</property>
                 <child>
                   <object class="AdwComboRow" id="custom_format_selection">
@@ -112,25 +110,32 @@
                   </object>
                 </child>
                 <child>
-                  <object class="AdwSpinRow">
-                    <signal name="notify::value" handler="on_samplerate_changed"></signal>
-                    <property name="title" translatable="yes">Sample Rate (Hz)</property>
-                    <property name="adjustment">
-                      <object class="GtkAdjustment">
-                        <property name="lower">8000</property>
-                        <property name="upper">96000</property>
-                        <property name="value">44100</property>
-                        <property name="page-increment">4000</property>
-                        <property name="step-increment">1000</property>
-                      </object>
-                    </property>
-                    <child type="suffix">
-                      <object class="GtkImage" id="samplerate_tooltip">
-                        <property name="visible">false</property>
-                        <property name="icon-name">dialog-warning-symbolic</property>
-                        <property name="has-tooltip">true</property>
-                        <property name="tooltip-text"
-                          translatable="yes">Samplerates other than 44100 or 48000 won't work well</property>
+                  <object class="AdwExpanderRow">
+                    <property name="title" translatable="yes">Change Sample Rate</property>
+                    <property name="show-enable-switch">true</property>
+                    <property name="enable-expansion">false</property>
+                    <signal name="notify::enable-expansion" handler="on_samplerate_expand"></signal>
+                    <child>
+                      <object class="AdwSpinRow" id="samplerate_row">
+                        <signal name="notify::value" handler="on_samplerate_changed"></signal>
+                        <property name="title" translatable="yes">Hertz (Hz)</property>
+                        <property name="adjustment">
+                          <object class="GtkAdjustment">
+                            <property name="lower">8000</property>
+                            <property name="upper">96000</property>
+                            <property name="value">44100</property>
+                            <property name="page-increment">4000</property>
+                            <property name="step-increment">1000</property>
+                          </object>
+                        </property>
+                        <child type="suffix">
+                          <object class="GtkImage" id="samplerate_tooltip">
+                            <property name="visible">false</property>
+                            <property name="icon-name">dialog-warning-symbolic</property>
+                            <property name="has-tooltip">true</property>
+                            <property name="tooltip-text" translatable="yes">Samplerates other than 44100 or 48000 won't work well</property>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

Closes #ISSUE

## Description

Changes how the custom quality is configured, by allowing to also _toggle_ the property, instead of setting a specific value. It uses an AdwExpanderRow with a switch to toggle it on and off. And it is disabled by default.

Disabling things like bitrate, means it'll set the quality to whatever the encoder uses by default. This means it **won't pick up the highest quality**. Unfortunately this means it could change depending on the format.
For most formats, they usually end up setting the bitrate to something like 128 kbps by default.

## Screenshots

Enabling properties:
<img width="594" height="359" alt="image" src="https://github.com/user-attachments/assets/8ee511af-1c9f-41ed-b204-749a80f56c97" />

Disabling properties:
<img width="594" height="244" alt="image" src="https://github.com/user-attachments/assets/5d4236c9-ff17-416a-9ecc-c81cfc6e8395" />


## Checklist

- [X] Your code builds clean without any errors (`just compile`)
- [X] Added in-code documentation (`valadoc`)
- [X] Ran the linter to ensure style guidelines were followed (`just lint`)
