### PR TITLE
Add basic support for bitdepth in quality

### DIFF
--- a/data/presets.json
+++ b/data/presets.json
@@ -50,24 +50,28 @@
             "name": "High Quality",
             "format": "m4a",
             "bitrate": 192,
+            "bitdepth_format": "",
             "samplerate": 48000
         },
         "standard": {
             "name": "Standard Quality",
             "format": "m4a",
             "bitrate": 128,
+            "bitdepth_format": "",
             "samplerate": 44100
         },
         "libre": {
             "name": "Libre (ogg)",
             "format": "vogg",
             "bitrate": 128,
+            "bitdepth_format": "",
             "samplerate": 44100
         },
         "compatibility": {
             "name": "Compatibility",
             "format": "mp3",
             "bitrate": 128,
+            "bitdepth_format": "",
             "samplerate": 44100
         }
     }

--- a/src/compress_config.vala
+++ b/src/compress_config.vala
@@ -52,10 +52,17 @@ public struct Press.FormatConfig {
  * Except for a custom config, it should never be changed.
  */
 public struct Press.QualityConfig {
+    /** Quality display name */
     public string name;
     public Press.FormatConfig format;
+    /** Bit rate in Kbps */
     public int bitrate;
+    /** Sample rate in Hz */
     public int samplerate;
+    /**
+     * String representing a bit depth format by a GStreamer caps filter.
+     * Such as: S16LE, U8, F64LE, S32BE, etc...
+     */
     public string bitdepth_format;
 }
 

--- a/src/compress_config.vala
+++ b/src/compress_config.vala
@@ -32,7 +32,6 @@ public interface Press.Cloneable<T> {
      * Create a deep copy of ``this``
      */
     public abstract T clone ();
-
 }
 
 /**
@@ -42,7 +41,7 @@ public struct Press.FormatConfig {
     public string name;
     public string extension;
     public string encoder;
-    public HashMap<string, Value ?> encoder_properties;
+    public HashMap<string, Value?> encoder_properties;
     public int bitrate_multiplier;
     public string[] filters;
 }
@@ -57,6 +56,7 @@ public struct Press.QualityConfig {
     public Press.FormatConfig format;
     public int bitrate;
     public int samplerate;
+    public string bitdepth_format;
 }
 
 /**
@@ -93,5 +93,4 @@ public class Press.CompressConfig : Press.Cloneable<Press.CompressConfig> {
         config.replace_destination_files = this.replace_destination_files;
         return config;
     }
-
 }

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -200,8 +200,15 @@ namespace Press {
             if (quality.bitrate * quality.format.bitrate_multiplier > 0)
                 encoder.set ("bitrate", quality.bitrate * quality.format.bitrate_multiplier);
 
+            string capsfilter_string = "audio/x-raw";
             if (quality.samplerate > 0)
-                samplerate_capsfilter.set ("caps", Gst.Caps.from_string (@"audio/x-raw,rate=$(quality.samplerate)"));
+                capsfilter_string += ",rate=%d".printf (quality.samplerate);
+
+            if (quality.bitdepth_format.length > 0)
+                capsfilter_string += ",format=%s".printf (quality.bitdepth_format);
+
+            if (capsfilter_string != "audio/x-raw")
+                samplerate_capsfilter.set ("caps", Gst.Caps.from_string (capsfilter_string));
 
             // Encoder properties
             foreach (var property in quality.format.encoder_properties ) {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -205,7 +205,7 @@ namespace Press {
             if (quality.samplerate > 0)
                 capsfilter_string += ",rate=%d".printf (quality.samplerate);
 
-            if (quality.bitdepth_format.length > 0)
+            if (quality.bitdepth_format != null && quality.bitdepth_format != "")
                 capsfilter_string += ",format=%s".printf (quality.bitdepth_format);
 
             if (capsfilter_string != "audio/x-raw")
@@ -472,7 +472,7 @@ namespace Press {
 
             debug (@"Processing $(source_file.get_basename ()) @ "
                    + @"$(file_config.quality_config.bitrate) bps, $(file_config.quality_config.samplerate) Hz, "
-                   + @"depth as $(file_config.quality_config.bitdepth_format)");
+                   + @"depth as $(file_config.quality_config.bitdepth_format ?? "null")");
 
             FileHandler file_handler;
             if (is_audio) {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -191,7 +191,8 @@ namespace Press {
          *
          * A bitrate multiplier of 0 means avoiding setting the bitrate entirely. Which is required for Lossless formats.
          *
-         * If bitrate or samplerate is less or equal to 0, then they wont be enforced respectively.
+         * If bitrate or samplerate is less or equal to 0, then they wont be enforced respectively. Bit depth is
+         * ignored if it's null or an empty string.
          */
         private void configure_elements (File source_file, File target_file) {
             source.set ("location", source_file.get_path ());

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -471,7 +471,8 @@ namespace Press {
                 throw new CompressError.IGNORED_FILE ("File exists, and replace destination files is disabled");
 
             debug (@"Processing $(source_file.get_basename ()) @ "
-                   + "$(file_config.quality_config.bitrate) bps, $(file_config.quality_config.samplerate) Hz");
+                   + @"$(file_config.quality_config.bitrate) bps, $(file_config.quality_config.samplerate) Hz, "
+                   + @"depth as $(file_config.quality_config.bitdepth_format)");
 
             FileHandler file_handler;
             if (is_audio) {

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -42,7 +42,6 @@ public class Press.ConfigPage : Adw.NavigationPage {
     [GtkChild] private unowned Adw.SwitchRow replace_destination_files_switch;
     [GtkChild] private unowned Adw.SwitchRow copy_noaudio_files_switch;
     [GtkChild] private unowned Adw.SpinRow bitrate_row;
-    [GtkChild] private unowned Adw.ComboRow bitdepth_row;
     [GtkChild] private unowned Adw.SpinRow samplerate_row;
     [GtkChild] private unowned Gtk.Image samplerate_tooltip;
 
@@ -216,16 +215,9 @@ public class Press.ConfigPage : Adw.NavigationPage {
     }
 
     [GtkCallback]
-    private void on_bitdepth_changed (GLib.Object obj, GLib.ParamSpec _) {
-        // TODO
-    }
-
-    [GtkCallback]
-    private void on_bitdepth_expand (GLib.Object obj, GLib.ParamSpec _) {
-        var expander_row = obj as Adw.ExpanderRow;
-        var expansion_enabled = expander_row.enable_expansion;
-
-        // TODO
+    private void on_bitdepth16_switched (GLib.Object obj, GLib.ParamSpec _) {
+        var switch_row = obj as Adw.SwitchRow;
+        var value = switch_row.active;
     }
 
     [GtkCallback]

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -218,6 +218,10 @@ public class Press.ConfigPage : Adw.NavigationPage {
     private void on_bitdepth16_switched (GLib.Object obj, GLib.ParamSpec _) {
         var switch_row = obj as Adw.SwitchRow;
         var value = switch_row.active;
+
+        var custom_quality = quality_list[CUSTOM_QUALITY_NAME];
+        custom_quality.bitdepth_format = value ? "S16LE" : null;
+        update_custom_quality (custom_quality);
     }
 
     [GtkCallback]

--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -42,6 +42,7 @@ public class Press.ConfigPage : Adw.NavigationPage {
     [GtkChild] private unowned Adw.SwitchRow replace_destination_files_switch;
     [GtkChild] private unowned Adw.SwitchRow copy_noaudio_files_switch;
     [GtkChild] private unowned Adw.SpinRow bitrate_row;
+    [GtkChild] private unowned Adw.ComboRow bitdepth_row;
     [GtkChild] private unowned Adw.SpinRow samplerate_row;
     [GtkChild] private unowned Gtk.Image samplerate_tooltip;
 
@@ -212,6 +213,19 @@ public class Press.ConfigPage : Adw.NavigationPage {
         var custom_quality = quality_list[CUSTOM_QUALITY_NAME];
         custom_quality.bitrate = expansion_enabled ? (int) bitrate_row.value : 0;
         update_custom_quality (custom_quality);
+    }
+
+    [GtkCallback]
+    private void on_bitdepth_changed (GLib.Object obj, GLib.ParamSpec _) {
+        // TODO
+    }
+
+    [GtkCallback]
+    private void on_bitdepth_expand (GLib.Object obj, GLib.ParamSpec _) {
+        var expander_row = obj as Adw.ExpanderRow;
+        var expansion_enabled = expander_row.enable_expansion;
+
+        // TODO
     }
 
     [GtkCallback]

--- a/src/presets_loader.vala
+++ b/src/presets_loader.vala
@@ -87,7 +87,7 @@ namespace Press {
          * @param display_name should be sent already translated
          */
         public void add_custom_quality (string name, string display_name) {
-            quality_list[name] = { display_name, null, 0, 0 };
+            quality_list[name] = { display_name, null, 0, 0, null };
         }
 
         /**

--- a/src/presets_loader.vala
+++ b/src/presets_loader.vala
@@ -173,6 +173,7 @@ namespace Press {
                         name = _(quality_obj.get_string_member ("name")),
                         format = format,
                         bitrate = (int32) quality_obj.get_int_member ("bitrate"),
+                        bitdepth_format = quality_obj.get_string_member ("bitdepth_format"),
                         samplerate = (int32) quality_obj.get_int_member ("samplerate")
                     };
 

--- a/src/ui/config_page.ui
+++ b/src/ui/config_page.ui
@@ -118,17 +118,10 @@
                   </object>
                 </child>
                 <child>
-                  <object class="AdwExpanderRow">
-                    <property name="title" translatable="yes">Change Bit Depth</property>
-                    <property name="show-enable-switch">true</property>
-                    <property name="enable-expansion">false</property>
-                    <signal name="notify::enable-expansion" handler="on_bitdepth_expand"></signal>
-                    <child>
-                      <object class="AdwComboRow" id="bitdepth_row">
-                        <signal name="notify::value" handler="on_bitdepth_changed"></signal>
-                        <property name="title" translatable="yes">Bits (Little Endian)</property>
-                      </object>
-                    </child>
+                  <object class="AdwSwitchRow">
+                    <property name="title" translatable="yes">Set Bit-depth to 16-bit</property>
+                    <property name="active">false</property>
+                    <signal name="notify::active" handler="on_bitdepth16_switched"></signal>
                   </object>
                 </child>
                 <child>

--- a/src/ui/config_page.ui
+++ b/src/ui/config_page.ui
@@ -119,6 +119,20 @@
                 </child>
                 <child>
                   <object class="AdwExpanderRow">
+                    <property name="title" translatable="yes">Change Bit Depth</property>
+                    <property name="show-enable-switch">true</property>
+                    <property name="enable-expansion">false</property>
+                    <signal name="notify::enable-expansion" handler="on_bitdepth_expand"></signal>
+                    <child>
+                      <object class="AdwComboRow" id="bitdepth_row">
+                        <signal name="notify::value" handler="on_bitdepth_changed"></signal>
+                        <property name="title" translatable="yes">Bits (Little Endian)</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwExpanderRow">
                     <property name="title" translatable="yes">Change Sample Rate</property>
                     <property name="show-enable-switch">true</property>
                     <property name="enable-expansion">false</property>


### PR DESCRIPTION
Closes #26 

## Description

Adds bit depth (format) support on the quality config struct. It also includes a very basic switch to force it to signed 16-bit Little Endian.

This PR doesn't include an intricate configuration for bit depth, because I believe this is not really useful for most use cases. If someone wants to convert their music library, 16-bit is the ideal bit depth. More in #26.

This implementation makes the bit depth a string, which means one could add support for other bit depth formats if needed.

## Screenshots

The new UI part is "Set Bit-depth..."
<img width="525" height="258" alt="image" src="https://github.com/user-attachments/assets/4dda5c58-5b86-42ac-8f53-cc8a3c52eebc" />


## Checklist

- [x] Your code builds clean without any errors (`just compile`)
- [x] Added in-code documentation (`valadoc`) (missing the string null or empty.)
- [x] Ran the linter to ensure style guidelines were followed (`just lint`)
- [x] Add the option to quality presets