### PR TITLE
fix: missing option when removing doc dir in justfile

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -32,7 +32,7 @@ lint-fix:
 
 # Clean and create the generated documentation directory
 docs-setup:
-    rm -r {{ docdir }}
+    rm -rf {{ docdir }}
     mkdir {{ docdir }}
 
 docs-generate:


### PR DESCRIPTION
## Description

Fix missing option when removing doc dir in justfile. Would fail if the docs hadn't been generated by then.

## Checklist

These don't apply