### PR TITLE
fix: :bug: Editorconfig missing .ui files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,5 @@ max_line_length = 80
 tab_width = 4
 
 # Markup files
-[{*.html,*.xml,*.xml.in,*.yml}]
+[{*.html,*.xml,*.xml.in,*.yml,*.ui}]
 tab_width = 2


### PR DESCRIPTION
## Description

fix: Editorconfig missing .ui files. Must have been missed when integrating the new .editorconfig file. The UI file is xml after all.

## Checklist

Not applicable