### PR TITLE
Add supports tag, with desktop and mobile support in metainfo

### DIFF
--- a/data/io.github.masakk1.press.metainfo.xml.in
+++ b/data/io.github.masakk1.press.metainfo.xml.in
@@ -39,6 +39,12 @@
   <!-- (https://hughsie.github.io/oars/generate.html) - use oars-1.1 -->
   <content_rating type="oars-1.1" />
 
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </supports>
+
   <branding>
     <color type="primary" scheme_preference="light">#c061cb</color>
     <color type="primary" scheme_preference="dark">#613583</color>


### PR DESCRIPTION
Closes #19 

## Description

Adds the required support tag in the `metainfo.xml` file, to support desktop and mobile (touch) devices.

Testing mobile support is quite simple, since the GTK Inspector has an "Adaptive Preview" window. This is accessed in GTK Inspector Window > Adwaita, Scroll to bottom > Adaptive Preview

## Screenshots

<img width="414" height="856" alt="image" src="https://github.com/user-attachments/assets/cf67a1bb-5d71-4459-85fb-78ad8b58c13b" />

## Checklist

N/A, no code was modified.
