### PR TITLE
Add Progress bar and refactor status message to "finished" instead of "started" 

### DIFF
--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -360,7 +360,10 @@ namespace Press {
                             Idle.add (() => {
                                 /* NOTE: completed_threads is safe in this Idle callback */
                                 this.finished_file (file.get_basename (), ++completed_threads, total_files, success);
-                                debug (@"Finished processing file $(file.get_path ()). Success: $success. Thread: $completed_threads/$total_files");
+
+                                debug (@"Finished processing file $(file.get_path ()). "
+                                       + @"Success: $success. Thread: $completed_threads/$total_files");
+
                                 return Source.REMOVE;
                             });
                         }

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -285,12 +285,6 @@ namespace Press {
         private File source_folder;
         private File target_folder;
 
-        /* TODO: Remove working on */
-        /**
-         * Called when a file is about to be processed.
-         */
-        public signal void working_on_file (string path);
-
         /**
          * Called when a file has been fully processed. Returns information about the results and what's left.
          * @param filename The path of the file that was processed
@@ -350,13 +344,6 @@ namespace Press {
                 int completed_threads = 0;
                 var pool = new ThreadPool<File>.with_owned_data ((file) => {
                     if (!cancelled) {
-                        /* TODO: Remove working on */
-                        Idle.add (() => {
-                            this.working_on_file (file.get_basename ());
-                            return Source.REMOVE;
-                        });
-
-                        debug (@"Processing file $(file.get_path ())");
                         bool success = false;
 
                         try {

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -287,12 +287,12 @@ namespace Press {
 
         /**
          * Called when a file has been fully processed. Returns information about the results and what's left.
-         * @param filename The path of the file that was processed
+         * @param file_name The path of the file that was processed
          * @param index The index of the file that was processed, in relation to the total
          * @param total The total number of files to process
          * @param success Whether the file was processed successfully
          */
-        public signal void finished_file (string filename, int index, int total, bool success);
+        public signal void finished_file (string file_name, int index, int total, bool success);
 
         private bool running = false;
         private bool cancelled = false;

--- a/src/compressor.vala
+++ b/src/compressor.vala
@@ -285,10 +285,20 @@ namespace Press {
         private File source_folder;
         private File target_folder;
 
+        /* TODO: Remove working on */
         /**
          * Called when a file is about to be processed.
          */
         public signal void working_on_file (string path);
+
+        /**
+         * Called when a file has been fully processed. Returns information about the results and what's left.
+         * @param filename The path of the file that was processed
+         * @param index The index of the file that was processed, in relation to the total
+         * @param total The total number of files to process
+         * @param success Whether the file was processed successfully
+         */
+        public signal void finished_file (string filename, int index, int total, bool success);
 
         private bool running = false;
         private bool cancelled = false;
@@ -334,25 +344,38 @@ namespace Press {
             cancelled = false;
 
             var children = get_children (source_folder);
+            int total_files = children.size;
 
             try {
+                int completed_threads = 0;
                 var pool = new ThreadPool<File>.with_owned_data ((file) => {
                     if (!cancelled) {
+                        /* TODO: Remove working on */
                         Idle.add (() => {
                             this.working_on_file (file.get_basename ());
                             return Source.REMOVE;
                         });
 
                         debug (@"Processing file $(file.get_path ())");
+                        bool success = false;
 
                         try {
                             process_file (file);
+                            /* if everything went correctly */
+                            success = true;
                         } catch (CompressError.IGNORED_FILE err) {
                             debug (@"Skipping $(file.get_path ()). Reason: $(err.message)");
                         } catch (CompressError.PROCESS err) {
                             warning (@"Failed during processing on $(file.get_path ()). Error: $(err.message)");
                         } catch (Error err) {
                             warning (@"Failed to process $(file.get_path ()). Error: $(err.message)");
+                        } finally {
+                            Idle.add (() => {
+                                /* NOTE: completed_threads is safe in this Idle callback */
+                                this.finished_file (file.get_basename (), ++completed_threads, total_files, success);
+                                debug (@"Finished processing file $(file.get_path ()). Success: $success. Thread: $completed_threads/$total_files");
+                                return Source.REMOVE;
+                            });
                         }
                     }
                 }, (int) GLib.get_num_processors (), false);

--- a/src/ui/window.ui
+++ b/src/ui/window.ui
@@ -20,6 +20,7 @@
                 <property name="can-pop">false</property>
                 <child>
                   <object class="AdwToolbarView">
+                    <property name="height-request">300</property>
                     <child type="top">
                       <object class="AdwHeaderBar">
                         <child type="start">
@@ -35,12 +36,19 @@
                     <property name="content">
                       <object class="AdwStatusPage" id="compressing_status_page">
                         <property name="title" translatable="yes">Compressing</property>
-                        <property name="description">...</property>
-                        <property name="paintable">
-                          <object class="AdwSpinnerPaintable">
-                            <property name="widget">compressing_status_page</property>
+                        <child>
+                          <object class="AdwClamp">
+                            <property name="maximum-size">600</property>
+                            <property name="tightening-threshold">300</property>
+                            <child>
+                              <object class="GtkProgressBar" id="compressing_progress_bar">
+                                <property name="show-text">true</property>
+                                <property name="fraction">0.2</property>
+                                <property name="halign">fill</property>
+                              </object>
+                            </child>
                           </object>
-                        </property>
+                        </child>
                       </object>
                     </property>
                   </object>
@@ -72,9 +80,7 @@
                     <property name="content">
                       <object class="AdwStatusPage">
                         <property name="title" translatable="yes">All done!</property>
-                        <property
-                          name="description"
-                          translatable="yes">Your files are now compressed at the target directory.</property>
+                        <property name="description" translatable="yes">Your files are now compressed at the target directory.</property>
                       </object>
                     </property>
                   </object>
@@ -87,9 +93,7 @@
     </property>
     <object class="AdwAlertDialog" id="confirm_dialog">
       <property name="heading" translatable="yes">Compress and replace all files?</property>
-      <property
-        name="body"
-        translatable="yes">This will replace files with the same name at the destination directory.</property>
+      <property name="body" translatable="yes">This will replace files with the same name at the destination directory.</property>
       <property name="default-response">compress</property>
       <property name="close-response">cancel</property>
       <responses>
@@ -99,9 +103,7 @@
     </object>
     <object class="AdwAlertDialog" id="cancel_dialog">
       <property name="heading" translatable="yes">Cancel compression?</property>
-      <property
-        name="body"
-        translatable="yes">This will stop the compression, but wont remove the changes already made.</property>
+      <property name="body" translatable="yes">This will stop the compression, but wont remove the changes already made.</property>
       <property name="default-response">continue</property>
       <property name="close-response">continue</property>
       <responses>

--- a/src/ui/window.ui
+++ b/src/ui/window.ui
@@ -43,7 +43,6 @@
                             <child>
                               <object class="GtkProgressBar" id="compressing_progress_bar">
                                 <property name="show-text">true</property>
-                                <property name="fraction">0.2</property>
                                 <property name="halign">fill</property>
                               </object>
                             </child>

--- a/src/window.vala
+++ b/src/window.vala
@@ -33,6 +33,7 @@ public class Press.Window : Adw.ApplicationWindow {
 
     [GtkChild] private unowned Adw.AlertDialog confirm_dialog;
     [GtkChild] private unowned Gtk.Button cancel_compressing_button;
+    [GtkChild] private unowned Gtk.ProgressBar compressing_progress_bar;
     [GtkChild] private unowned Adw.AlertDialog cancel_dialog;
     [GtkChild] private unowned Adw.StatusPage compressing_status_page;
     [GtkChild] private unowned Gtk.Button done_page_back_button;
@@ -58,7 +59,7 @@ public class Press.Window : Adw.ApplicationWindow {
         // In compressing page
         cancel_compressing_button.clicked.connect (open_cancel_dialog);
         cancel_dialog.response.connect (answer_cancel_dialog);
-        compressor.working_on_file.connect (change_working_on);
+        compressor.finished_file.connect (finished_file);
 
         // In done page
         done_page_back_button.clicked.connect (return_config_page);
@@ -92,8 +93,9 @@ public class Press.Window : Adw.ApplicationWindow {
         }
     }
 
-    private void change_working_on (string job) {
-        compressing_status_page.description = _("Working on %s").printf (job);
+    private void finished_file (string file_name, int thread_index, int total_threads, bool success) {
+        compressing_progress_bar.fraction = thread_index / (float) total_threads;
+        compressing_status_page.description = _("Finished %s (%d/%d)").printf (file_name, thread_index, total_threads);
     }
 
     /**
@@ -127,7 +129,7 @@ public class Press.Window : Adw.ApplicationWindow {
 
     private void cancel_compression () {
         compressor.cancel ();
-        change_working_on (_("cancelling"));
+        compressing_status_page.description = _("Gracefully cancelling...");
     }
 
     private void return_config_page () {

--- a/src/window.vala
+++ b/src/window.vala
@@ -98,6 +98,11 @@ public class Press.Window : Adw.ApplicationWindow {
         compressing_status_page.description = _("Finished %s (%d/%d)").printf (file_name, thread_index, total_threads);
     }
 
+    private void clean_compressing_page () {
+        compressing_progress_bar.fraction = 0;
+        compressing_status_page.description = "";
+    }
+
     /**
      * Begins the compression.
      *
@@ -121,6 +126,8 @@ public class Press.Window : Adw.ApplicationWindow {
                     navigation_view.push_by_tag ("done_page");
                 else
                     navigation_view.pop_to_tag ("config_page");
+
+                clean_compressing_page ();
             });
         } else {
             toast_overlay.add_toast (new Adw.Toast (_("Selected folders don't exist")));

--- a/src/window.vala
+++ b/src/window.vala
@@ -136,7 +136,7 @@ public class Press.Window : Adw.ApplicationWindow {
 
     private void cancel_compression () {
         compressor.cancel ();
-        compressing_status_page.description = _("Gracefully cancelling...");
+        compressing_status_page.description = _("Gracefully cancelling…");
     }
 
     private void return_config_page () {


### PR DESCRIPTION
Closes #28 

## Description

This PR adds a Gtk.ProgressBar, replacing the spinner in the Compressing Status Page. The progress bar also has an Adw.Clamp to make it fit better. Then it also reworks the status "worked on" message.

Press was missing a progress bar for some time now, and it was very hard to guess how long it's been, and the user was left to "guess where it could be at". A progress bar really helps create a sense of progress.

The current status message of "working on" was alright for a basic sense of progress, but it had clear problems: It's misleading - one might think that if it's hung up on "Working on my_cover.jpg", that image is huge or has problems, when in reality that one is probably done already and it's another file that's being transcoded. This PR doesn't fully solve this, it doesn't provide a comprehensive list of all the files that are being worked on. But at least changes how the status description shows file to prevent confusions.
The solution here is to show when a file is _finished_, and display "Finished my_song.flac" instead. - This is less misleading.

Technically speaking, that is replacing the `working_on` signal for a `finished_file` signal. This new signal is what ultimately updates the progress bar, as it sends both the file it's finished, as well as the _index_ and _total_. We can get the percentage of done files with this.

A technical hurdle was how files are analyzed: we don't analyze all of the files and then process them. Instead, analyzing them is part of the `process_file` function. This means we can't know how many files are going to be truly processed or skipped. To remedy this, when showing (index/total), we take into consideration _even the files that are going to be skipped_.
This solution isn't ideal, since we'll be showing 30 out of 62 when in reality we're only processing 40 files. But we can just lie about it and increase the number anyway. That way, the progress bar will be correct, even though we could be displaying "Finished cover.jpg" even though it's actually been skipped.
Ultimately this solution seems fine to me.

Lastly, the `finished_file` signal also sends a "success" flag. Nothing is done with it, but it already works to check if there were any errors - we can easily display which files had errors later on.

## Screenshots

- Removed spinner
- Added progress bar within a clamp
- Changed status message from "working on ..." to "finished ..."

<img width="850" height="650" alt="image" src="https://github.com/user-attachments/assets/13d428d3-4c3b-4a77-9900-ae8d1a676f08" />

## Checklist

- [X] Your code builds clean without any errors (`just compile`)
- [X] Added in-code documentation (`valadoc`)
- [X] Ran the linter to ensure style guidelines were followed (`just lint`)