### PR TITLE
Ignore null folder paths in source and target directory

### DIFF
--- a/src/config_page.vala
+++ b/src/config_page.vala
@@ -95,20 +95,24 @@ public class Press.ConfigPage : Adw.NavigationPage {
     [GtkCallback]
     private void on_source_directory_clicked (Gtk.Button button) {
         select_directory ((folder) => {
-            string path = folder != null ? folder.get_path () : "nothing";
+            string? path = folder ? .get_path ();
 
-            config.source_path = path;
-            source_directory_row.subtitle = path;
+            if (path != null) {
+                config.source_path = path;
+                source_directory_row.subtitle = path;
+            }
         });
     }
 
     [GtkCallback]
     private void on_target_directory_clicked (Gtk.Button button) {
         select_directory ((folder) => {
-            string? path = folder != null ? folder.get_path () : "nothing";
+            string? path = folder ? .get_path ();
 
-            config.target_path = path;
-            target_directory_row.subtitle = path;
+            if (path != null) {
+                config.target_path = path;
+                target_directory_row.subtitle = path;
+            }
         });
     }
 


### PR DESCRIPTION
Closes #24 

## Description

Simple fix for a bug that showed an untranslated `nothing` string
Instead, do nothing if a null path was selected.

## Screenshots

N/A

## Checklist

- [X] Your code builds clean without any errors (`just compile`)
- [X] Added in-code documentation (`valadoc`)
- [X] Ran the linter to ensure style guidelines were followed (`just lint`)
